### PR TITLE
feat: hard-cutover external naming to Memories

### DIFF
--- a/CLOUD_SYNC_DESIGN.md
+++ b/CLOUD_SYNC_DESIGN.md
@@ -27,13 +27,13 @@
 ```yaml
 CLOUD_SYNC_ENABLED=true              # Enable cloud sync feature
 CLOUD_SYNC_PROVIDER=s3               # Always "s3" for Phase 1
-CLOUD_SYNC_BUCKET=my-faiss-memory    # S3 bucket name
+CLOUD_SYNC_BUCKET=my-memories    # S3 bucket name
 CLOUD_SYNC_ENDPOINT=                 # Optional: custom endpoint (for MinIO, B2, etc.)
 CLOUD_SYNC_REGION=us-east-1          # AWS region
 CLOUD_SYNC_ACCESS_KEY=AKIA...        # S3 access key
 CLOUD_SYNC_SECRET_KEY=...            # S3 secret key
 CLOUD_SYNC_SCHEDULE=0 2 * * *        # Cron format (default: 2am daily)
-CLOUD_SYNC_PREFIX=faiss-memory/      # Optional: prefix path in bucket
+CLOUD_SYNC_PREFIX=memories/      # Optional: prefix path in bucket
 ```
 
 ---

--- a/CLOUD_SYNC_README.md
+++ b/CLOUD_SYNC_README.md
@@ -14,14 +14,14 @@ Cloud sync is **opt-in** to keep the Docker image lean (saves ~80MB).
 Build the image with cloud sync enabled:
 
 ```bash
-docker build --target core --build-arg ENABLE_CLOUD_SYNC=true -t faiss-memory:core .
-# or: docker build --target extract --build-arg ENABLE_CLOUD_SYNC=true -t faiss-memory:extract .
+docker build --target core --build-arg ENABLE_CLOUD_SYNC=true -t memories:core .
+# or: docker build --target extract --build-arg ENABLE_CLOUD_SYNC=true -t memories:extract .
 ```
 
 ### Option 2: Install Manually (if already running)
 
 ```bash
-docker exec faiss-memory pip install boto3==1.35.36
+docker exec memories pip install boto3==1.35.36
 ```
 
 ### Option 3: Local Development
@@ -35,7 +35,7 @@ pip install -r requirements-cloud.txt
 
 ## Overview
 
-Cloud Sync automatically backs up your FAISS memory index to S3-compatible cloud storage. This enables:
+Cloud Sync automatically backs up your Memories memory index to S3-compatible cloud storage. This enables:
 
 - **Cross-machine sync** - Use the same memories on multiple machines
 - **Disaster recovery** - Never lose your memories if a machine fails
@@ -52,7 +52,7 @@ Add these environment variables to your `docker-compose.yml`:
 ```yaml
 environment:
   - CLOUD_SYNC_ENABLED=true
-  - CLOUD_SYNC_BUCKET=my-faiss-memory
+  - CLOUD_SYNC_BUCKET=my-memories
   - CLOUD_SYNC_REGION=us-east-1
   - CLOUD_SYNC_ACCESS_KEY=AKIA...
   - CLOUD_SYNC_SECRET_KEY=...
@@ -82,7 +82,7 @@ curl http://localhost:8900/sync/status
 | `CLOUD_SYNC_ENABLED` | No | `false` | Enable cloud sync |
 | `CLOUD_SYNC_BUCKET` | Yes* | - | S3 bucket name |
 | `CLOUD_SYNC_REGION` | No | `us-east-1` | AWS region |
-| `CLOUD_SYNC_PREFIX` | No | `faiss-memory/` | Path prefix in bucket |
+| `CLOUD_SYNC_PREFIX` | No | `memories/` | Path prefix in bucket |
 | `CLOUD_SYNC_ACCESS_KEY` | No** | - | S3 access key |
 | `CLOUD_SYNC_SECRET_KEY` | No** | - | S3 secret key |
 | `CLOUD_SYNC_ENDPOINT` | No | - | Custom endpoint (for MinIO, B2, etc.) |
@@ -162,11 +162,11 @@ curl http://localhost:8900/sync/snapshots \
   "snapshots": [
     {
       "name": "manual_20260214_120000",
-      "s3_prefix": "faiss-memory/manual_20260214_120000/"
+      "s3_prefix": "memories/manual_20260214_120000/"
     },
     {
       "name": "auto_20260213_020000",
-      "s3_prefix": "faiss-memory/auto_20260213_020000/"
+      "s3_prefix": "memories/auto_20260213_020000/"
     }
   ],
   "count": 2
@@ -218,7 +218,7 @@ environment:
 
 **Create bucket:**
 ```bash
-aws s3 mb s3://my-faiss-memory --region us-east-1
+aws s3 mb s3://my-memories --region us-east-1
 ```
 
 ---
@@ -242,7 +242,7 @@ environment:
 ```yaml
 environment:
   - CLOUD_SYNC_ENABLED=true
-  - CLOUD_SYNC_BUCKET=faiss-memory
+  - CLOUD_SYNC_BUCKET=memories
   - CLOUD_SYNC_REGION=us-east-1
   - CLOUD_SYNC_ENDPOINT=http://minio.local:9000
   - CLOUD_SYNC_ACCESS_KEY=minioadmin
@@ -281,8 +281,8 @@ environment:
            "s3:ListBucket"
          ],
          "Resource": [
-           "arn:aws:s3:::my-faiss-memory",
-           "arn:aws:s3:::my-faiss-memory/*"
+           "arn:aws:s3:::my-memories",
+           "arn:aws:s3:::my-memories/*"
          ]
        }
      ]
@@ -311,7 +311,7 @@ environment:
 **Solutions:**
 1. Check `CLOUD_SYNC_ENABLED=true` is set
 2. Verify `CLOUD_SYNC_BUCKET` is configured
-3. Check container logs: `docker compose logs faiss-memory`
+3. Check container logs: `docker compose logs memories`
 
 ---
 
@@ -322,7 +322,7 @@ environment:
 **Solutions:**
 1. Check credentials are correct
 2. Verify bucket exists: `aws s3 ls s3://my-bucket`
-3. Test connectivity: `docker compose exec faiss-memory ping s3.amazonaws.com`
+3. Test connectivity: `docker compose exec memories ping s3.amazonaws.com`
 4. Check IAM permissions
 
 ---

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This is the fastest path to a working FAISS Memory setup with optional automatic extraction.
+This is the fastest path to a working Memories setup with optional automatic extraction.
 
 ## 1) Start the service
 
@@ -22,7 +22,7 @@ If `/ui` shows 404, rebuild to pick up current web assets:
 
 ```bash
 docker compose down
-docker compose up -d --build faiss-memory
+docker compose up -d --build memories
 ```
 
 ## 3) Choose your memory mode

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,4 +1,4 @@
-# PROJECT.md - FAISS Memory Maintainer Notes
+# PROJECT.md - Memories Maintainer Notes
 
 High-level maintainer-facing snapshot for the `memories` repository.
 
@@ -6,7 +6,7 @@ High-level maintainer-facing snapshot for the `memories` repository.
 
 ## What This Project Is
 
-FAISS Memory is a local-first memory service for AI assistants. It provides:
+Memories is a local-first memory service for AI assistants. It provides:
 
 - semantic and hybrid retrieval over stored memories
 - HTTP API for broad client compatibility
@@ -40,7 +40,7 @@ Persistent files under `DATA_DIR` (default `/data`):
 - `config.json`
 - `backups/` (rolling backups; controlled by `MAX_BACKUPS`)
 
-Key invariant: FAISS vector count must match metadata entry count.
+Key invariant: Memories vector count must match metadata entry count.
 
 ---
 
@@ -76,8 +76,8 @@ Memory controls:
 
 - Tests: `./.venv/bin/python -m pytest -q`
 - Local run: `./.venv/bin/python -m uvicorn app:app --reload`
-- Docker build (core): `docker build --target core -t faiss-memory:core .`
-- Docker build (extract): `docker build --target extract -t faiss-memory:extract .`
+- Docker build (core): `docker build --target core -t memories:core .`
+- Docker build (extract): `docker build --target extract -t memories:extract .`
 
 When changing memory/index behavior:
 
@@ -140,7 +140,7 @@ Integration docs:
 ### v1.2 (Future)
 
 - [ ] Multi-index support (different projects).
-- [x] Hybrid search (semantic + keyword) is implemented (FAISS + BM25 + RRF).
+- [x] Hybrid search (semantic + keyword) is implemented (Memories + BM25 + RRF).
 - [ ] Memory tagging system.
 - [ ] Search filters by source/date/type (source exists; date/type pending).
 - [ ] Scheduled index rebuilds via cron.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FAISS Memory
+# Memories
 
 Local semantic memory for AI assistants. Zero-cost, <50ms, hybrid BM25+vector search.
 
@@ -47,14 +47,14 @@ AI Client (Claude, Codex, ChatGPT, OpenClaw)
 MCP Server (mcp-server/index.js)
     |
     v
-FAISS Memory Service (Docker :8900)
+Memories Service (Docker :8900)
     |-- FastAPI REST API
-    |-- Hybrid Search (FAISS vector + BM25 keyword, RRF fusion)
+    |-- Hybrid Search (Memories vector + BM25 keyword, RRF fusion)
     |-- Markdown-aware chunking
     |-- Auto-backups
     v
 Persistent Storage (data/)
-    |-- index.faiss (FAISS binary index)
+    |-- index.faiss (Memories binary index)
     |-- metadata.json (memory text + metadata)
     |-- backups/ (auto, keeps last 10)
 ```
@@ -85,12 +85,12 @@ npm install
 ```json
 {
   "mcpServers": {
-    "faiss-memory": {
+    "memories": {
       "command": "node",
       "args": ["/path/to/memories/mcp-server/index.js"],
       "env": {
-        "FAISS_URL": "http://localhost:8900",
-        "FAISS_API_KEY": "your-api-key-here"
+        "MEMORIES_URL": "http://localhost:8900",
+        "MEMORIES_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -128,12 +128,12 @@ npm install
 ```json
 {
   "mcpServers": {
-    "faiss-memory": {
+    "memories": {
       "command": "node",
       "args": ["/path/to/memories/mcp-server/index.js"],
       "env": {
-        "FAISS_URL": "http://localhost:8900",
-        "FAISS_API_KEY": "your-api-key-here"
+        "MEMORIES_URL": "http://localhost:8900",
+        "MEMORIES_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -150,7 +150,7 @@ Claude Chat on the web does not support MCP directly. Two options:
 
 **Option A: Remote MCP via Cloudflare Tunnel (recommended)**
 
-If you expose the FAISS service via a tunnel (e.g., `memory.yourdomain.com`), you can use Claude's remote MCP connector feature to connect to it. See the [Remote Access](#remote-access) section below.
+If you expose the Memories service via a tunnel (e.g., `memory.yourdomain.com`), you can use Claude's remote MCP connector feature to connect to it. See the [Remote Access](#remote-access) section below.
 
 **Option B: Manual curl in prompts**
 
@@ -185,12 +185,12 @@ npm install
 ```json
 {
   "mcpServers": {
-    "faiss-memory": {
+    "memories": {
       "command": "node",
       "args": ["/path/to/memories/mcp-server/index.js"],
       "env": {
-        "FAISS_URL": "http://localhost:8900",
-        "FAISS_API_KEY": "your-api-key-here"
+        "MEMORIES_URL": "http://localhost:8900",
+        "MEMORIES_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -209,13 +209,13 @@ npm install
 
 ### ChatGPT (Custom GPT)
 
-ChatGPT uses **Custom Actions** (OpenAPI schema) rather than MCP. This requires exposing the FAISS service over the internet.
+ChatGPT uses **Custom Actions** (OpenAPI schema) rather than MCP. This requires exposing the Memories service over the internet.
 
-**Prerequisites:** FAISS service accessible via HTTPS (see [Remote Access](#remote-access)).
+**Prerequisites:** Memories service accessible via HTTPS (see [Remote Access](#remote-access)).
 
 **Setup:**
 
-1. Enable API key auth on the FAISS service (set `API_KEY` env var in docker-compose).
+1. Enable API key auth on the Memories service (set `API_KEY` env var in docker-compose).
 
 2. In ChatGPT, go to **Explore GPTs > Create a GPT > Configure > Actions**.
 
@@ -224,7 +224,7 @@ ChatGPT uses **Custom Actions** (OpenAPI schema) rather than MCP. This requires 
 ```yaml
 openapi: 3.0.0
 info:
-  title: FAISS Memory
+  title: Memories
   version: 2.0.0
   description: Semantic memory search and storage
 servers:
@@ -360,8 +360,8 @@ OpenClaw uses a **Skill** (SKILL.md) with shell helper functions that call the R
 1. Create the skill directory and copy the skill file:
 
 ```bash
-mkdir -p ~/.openclaw/skills/faiss-memory
-cp integrations/openclaw-skill.md ~/.openclaw/skills/faiss-memory/SKILL.md
+mkdir -p ~/.openclaw/skills/memories
+cp integrations/openclaw-skill.md ~/.openclaw/skills/memories/SKILL.md
 ```
 
 Or see the full SKILL.md in this repo at `integrations/openclaw-skill.md`.
@@ -369,35 +369,35 @@ Or see the full SKILL.md in this repo at `integrations/openclaw-skill.md`.
 2. Set the API key in your shell profile (`~/.zshrc` or `~/.bashrc`):
 
 ```bash
-export FAISS_API_KEY="your-api-key-here"
+export MEMORIES_API_KEY="your-api-key-here"
 ```
 
-The SKILL.md reads `$FAISS_API_KEY` from the environment — the key is never stored in the skill file itself.
+The SKILL.md reads `$MEMORIES_API_KEY` from the environment — the key is never stored in the skill file itself.
 
 **Key commands available to OpenClaw agents:**
 
 ```bash
-memory_search_faiss "query" [k] [threshold] [hybrid]
-memory_add_faiss "text" "source" [deduplicate]
+memory_search_memories "query" [k] [threshold] [hybrid]
+memory_add_memories "text" "source" [deduplicate]
 memory_is_novel "text" [threshold]
-memory_delete_faiss <id>
-memory_delete_source_faiss "pattern"
-memory_list_faiss [offset] [limit] [source]
+memory_delete_memories <id>
+memory_delete_source_memories "pattern"
+memory_list_memories [offset] [limit] [source]
 memory_rebuild_index
-memory_dedup_faiss [dry_run] [threshold]
+memory_dedup_memories [dry_run] [threshold]
 memory_stats
 memory_health
 memory_backup [prefix]
 memory_restore "backup_name"
 ```
 
-All functions use `jq` for safe JSON construction and read auth from `$FAISS_API_KEY` env var (no hardcoded secrets).
+All functions use `jq` for safe JSON construction and read auth from `$MEMORIES_API_KEY` env var (no hardcoded secrets).
 
 ---
 
 ## Remote Access
 
-To use FAISS Memory from anywhere (Claude Chat web, ChatGPT, mobile, other machines), expose it via a Cloudflare Tunnel or similar.
+To use Memories from anywhere (Claude Chat web, ChatGPT, mobile, other machines), expose it via a Cloudflare Tunnel or similar.
 
 ### Setup with Cloudflare Tunnel
 
@@ -408,7 +408,7 @@ environment:
   - API_KEY=your-secret-key-here
 ```
 
-Rebuild and restart: `docker compose build faiss-memory && docker compose up -d faiss-memory`
+Rebuild and restart: `docker compose build memories && docker compose up -d memories`
 
 2. **Add to your Cloudflare tunnel config** (e.g., in `~/.cloudflared/config.yml`):
 
@@ -423,8 +423,8 @@ ingress:
 ```json
 {
   "env": {
-    "FAISS_URL": "https://memory.yourdomain.com",
-    "FAISS_API_KEY": "your-secret-key-here"
+    "MEMORIES_URL": "https://memory.yourdomain.com",
+    "MEMORIES_API_KEY": "your-secret-key-here"
   }
 }
 ```
@@ -554,7 +554,7 @@ When connected via MCP (Claude Code, Claude Desktop, Codex), these tools are ava
 ### Docker Compose guardrails
 
 Default compose files now include:
-- `mem_limit: ${FAISS_MEM_LIMIT:-3g}` to bound container memory growth
+- `mem_limit: ${MEMORIES_MEM_LIMIT:-3g}` to bound container memory growth
 - `MALLOC_ARENA_MAX=2` to reduce glibc arena fragmentation in multithreaded workloads
 - `MALLOC_TRIM_THRESHOLD_=131072` and `MALLOC_MMAP_THRESHOLD_=131072` to encourage earlier allocator release
 - extraction env passthrough (`EXTRACT_PROVIDER`, `EXTRACT_MODEL`, provider keys/URL) so deploys keep extraction enabled when set in shell or `.env`
@@ -563,8 +563,8 @@ Default compose files now include:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FAISS_URL` | `http://localhost:8900` | FAISS service URL |
-| `FAISS_API_KEY` | (empty) | API key if auth is enabled |
+| `MEMORIES_URL` | `http://localhost:8900` | Memories service URL |
+| `MEMORIES_API_KEY` | (empty) | API key if auth is enabled |
 
 ---
 
@@ -592,7 +592,7 @@ Makes memory retrieval and extraction automatic — no manual search/store neede
 This detects and configures any available targets on your machine:
 - Claude Code hooks (`~/.claude/settings.json`)
 - Codex hooks (`~/.codex/settings.json`)
-- OpenClaw skill (`~/.openclaw/skills/faiss-memory/SKILL.md`)
+- OpenClaw skill (`~/.openclaw/skills/memories/SKILL.md`)
 
 **Target only Claude or Codex:**
 ```bash
@@ -662,18 +662,18 @@ The Dockerfile publishes two runtime targets:
 Build both images directly:
 
 ```bash
-docker build --target core -t faiss-memory:core .
-docker build --target extract -t faiss-memory:extract .
+docker build --target core -t memories:core .
+docker build --target extract -t memories:extract .
 ```
 
 Use compose with either target:
 
 ```bash
 # Default (core target)
-docker compose up -d --build faiss-memory
+docker compose up -d --build memories
 
 # Extraction-ready target
-FAISS_IMAGE_TARGET=extract docker compose up -d --build faiss-memory
+MEMORIES_IMAGE_TARGET=extract docker compose up -d --build memories
 ```
 
 By default, images do **not** bake model weights. On first run, the service downloads them into
@@ -682,8 +682,8 @@ By default, images do **not** bake model weights. On first run, the service down
 If you want a fully preloaded image (faster first boot, larger pull), set `PRELOAD_MODEL=true`:
 
 ```bash
-docker build --target core --build-arg PRELOAD_MODEL=true -t faiss-memory:core .
-docker build --target extract --build-arg PRELOAD_MODEL=true -t faiss-memory:extract .
+docker build --target core --build-arg PRELOAD_MODEL=true -t memories:core .
+docker build --target extract --build-arg PRELOAD_MODEL=true -t memories:extract .
 ```
 
 Ollama uses HTTP directly and does not need the extra SDKs, so `core` is enough for Ollama extraction.
@@ -727,7 +727,7 @@ Reference benchmark: `docs/benchmarks/2026-02-17-memory-reclamation.md`
 
 ## Backup & Recovery
 
-FAISS Memory has three layers of backup protection:
+Memories has three layers of backup protection:
 
 ### 1. Auto-backup (built-in)
 
@@ -735,20 +735,20 @@ The service automatically saves a snapshot after every write operation. The 10 m
 
 ```bash
 # List backups
-curl -H "X-API-Key: $FAISS_API_KEY" http://localhost:8900/backups
+curl -H "X-API-Key: $MEMORIES_API_KEY" http://localhost:8900/backups
 
 # Create manual backup
-curl -X POST -H "X-API-Key: $FAISS_API_KEY" http://localhost:8900/backup?prefix=manual
+curl -X POST -H "X-API-Key: $MEMORIES_API_KEY" http://localhost:8900/backup?prefix=manual
 
 # Restore from backup
-curl -X POST -H "X-API-Key: $FAISS_API_KEY" http://localhost:8900/restore \
+curl -X POST -H "X-API-Key: $MEMORIES_API_KEY" http://localhost:8900/restore \
   -H "Content-Type: application/json" \
   -d '{"backup_name": "manual_20260214_120000"}'
 ```
 
 ### 2. Scheduled local snapshots (cron)
 
-A cron job creates timestamped copies of the FAISS index every 30 minutes. Snapshots are stored outside the Docker volume (default: `~/backups/faiss-memory/`) with 30-day retention.
+A cron job creates timestamped copies of the Memories index every 30 minutes. Snapshots are stored outside the Docker volume (default: `~/backups/memories/`) with 30-day retention.
 
 ```bash
 # Install the cron job
@@ -768,10 +768,10 @@ A cron job creates timestamped copies of the FAISS index every 30 minutes. Snaps
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FAISS_URL` | `http://localhost:8900` | Service URL |
-| `FAISS_API_KEY` | (empty) | API key if auth is enabled |
-| `FAISS_DATA_DIR` | `./data` (relative to repo) | Docker volume data path |
-| `BACKUP_DIR` | `~/backups/faiss-memory` | Where to store snapshots |
+| `MEMORIES_URL` | `http://localhost:8900` | Service URL |
+| `MEMORIES_API_KEY` | (empty) | API key if auth is enabled |
+| `MEMORIES_DATA_DIR` | `./data` (relative to repo) | Docker volume data path |
+| `BACKUP_DIR` | `~/backups/memories` | Where to store snapshots |
 | `RETENTION_DAYS` | `30` | Days to keep local snapshots |
 
 ### 3. Off-site backup to Google Drive (optional)
@@ -793,7 +793,7 @@ export GDRIVE_ACCOUNT="your-email@gmail.com"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GDRIVE_ACCOUNT` | (none) | Google account email. **Required to enable GDrive.** |
-| `GDRIVE_FOLDER_NAME` | `faiss-memory-backups` | Folder name on Drive |
+| `GDRIVE_FOLDER_NAME` | `memories-backups` | Folder name on Drive |
 | `UPLOAD_INTERVAL_MIN` | `55` | Minimum minutes between uploads |
 | `GDRIVE_RETENTION_DAYS` | `7` | Days to keep backups on Drive |
 
@@ -818,7 +818,7 @@ export GDRIVE_ACCOUNT="your-email@gmail.com"
 For S3/MinIO/R2 backends, build with cloud sync enabled:
 
 ```bash
-ENABLE_CLOUD_SYNC=true docker compose up -d --build faiss-memory
+ENABLE_CLOUD_SYNC=true docker compose up -d --build memories
 ```
 
 See [CLOUD_SYNC_README.md](CLOUD_SYNC_README.md) for configuration details.
@@ -830,7 +830,7 @@ See [CLOUD_SYNC_README.md](CLOUD_SYNC_README.md) for configuration details.
 ```
 memories/
   app.py                  # FastAPI REST API
-  memory_engine.py        # FAISS engine (search, chunking, BM25, backups)
+  memory_engine.py        # Memories engine (search, chunking, BM25, backups)
   onnx_embedder.py        # ONNX Runtime embedder (replaces PyTorch)
   llm_provider.py         # LLM provider abstraction (Anthropic/OpenAI/Ollama)
   llm_extract.py          # Extraction pipeline with AUDN

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 """
-FAISS Memory API Service
-FastAPI wrapper for FAISS memory engine with auth, hybrid search,
+Memories API Service
+FastAPI wrapper for the Memories engine with auth, hybrid search,
 CRUD operations, and structured logging.
 """
 
@@ -33,7 +33,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
-logger = logging.getLogger("faiss-memory")
+logger = logging.getLogger("memories")
 
 # Optional extraction support
 try:
@@ -384,7 +384,7 @@ async def _periodic_memory_trim() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global memory
-    logger.info("Starting FAISS Memory service...")
+    logger.info("Starting Memories service...")
     memory = MemoryEngine(data_dir=DATA_DIR)
     logger.info(
         "Loaded %d memories (%s model, %d dims)",
@@ -416,7 +416,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="FAISS Memory API",
+    title="Memories API",
     version="2.0.0",
     lifespan=lifespan,
     dependencies=[Depends(verify_api_key)],
@@ -514,7 +514,7 @@ class SupersedeRequest(BaseModel):
 async def health():
     """Lightweight health check (no filesystem I/O)"""
     stats = memory.stats_light()
-    return {"status": "ok", "service": "faiss-memory", "version": "2.0.0", **stats}
+    return {"status": "ok", "service": "memories", "version": "2.0.0", **stats}
 
 
 @app.get("/ui", include_in_schema=False)

--- a/cloud_sync.py
+++ b/cloud_sync.py
@@ -1,6 +1,6 @@
 """
 Cloud Sync Module
-S3-compatible backup sync for FAISS Memory
+S3-compatible backup sync for Memories
 """
 
 import os
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from datetime import datetime, timezone
 
-logger = logging.getLogger("faiss-memory.cloud-sync")
+logger = logging.getLogger("memories.cloud-sync")
 
 try:
     import boto3
@@ -26,7 +26,7 @@ class CloudSync:
     def __init__(
         self,
         bucket: str,
-        prefix: str = "faiss-memory/",
+        prefix: str = "memories/",
         region: str = "us-east-1",
         endpoint_url: Optional[str] = None,
         access_key: Optional[str] = None,
@@ -171,7 +171,7 @@ class CloudSync:
 
         return cls(
             bucket=bucket,
-            prefix=os.getenv("CLOUD_SYNC_PREFIX", "faiss-memory/"),
+            prefix=os.getenv("CLOUD_SYNC_PREFIX", "memories/"),
             region=os.getenv("CLOUD_SYNC_REGION", "us-east-1"),
             endpoint_url=os.getenv("CLOUD_SYNC_ENDPOINT"),
             access_key=os.getenv("CLOUD_SYNC_ACCESS_KEY"),

--- a/docker-compose.snippet.yml
+++ b/docker-compose.snippet.yml
@@ -1,17 +1,17 @@
 # Add this to your existing ~/web/docker-compose.yml
 
 services:
-  faiss-memory:
+  memories:
     build:
       context: ../projects/memories
-      target: ${FAISS_IMAGE_TARGET:-core}
+      target: ${MEMORIES_IMAGE_TARGET:-core}
       args:
         ENABLE_CLOUD_SYNC: ${ENABLE_CLOUD_SYNC:-false}
         PRELOAD_MODEL: ${PRELOAD_MODEL:-false}
-    image: faiss-memory:${FAISS_IMAGE_TARGET:-core}
-    container_name: faiss-memory
+    image: memories:${MEMORIES_IMAGE_TARGET:-core}
+    container_name: memories
     restart: unless-stopped
-    mem_limit: ${FAISS_MEM_LIMIT:-3g}
+    mem_limit: ${MEMORIES_MEM_LIMIT:-3g}
     ports:
       - "8900:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 services:
-  faiss-memory:
+  memories:
     build:
       context: .
-      target: ${FAISS_IMAGE_TARGET:-core}
+      target: ${MEMORIES_IMAGE_TARGET:-core}
       args:
         ENABLE_CLOUD_SYNC: ${ENABLE_CLOUD_SYNC:-false}
         PRELOAD_MODEL: ${PRELOAD_MODEL:-false}
-    image: faiss-memory:${FAISS_IMAGE_TARGET:-core}
-    container_name: faiss-memory
+    image: memories:${MEMORIES_IMAGE_TARGET:-core}
+    container_name: memories
     restart: unless-stopped
-    mem_limit: ${FAISS_MEM_LIMIT:-3g}
+    mem_limit: ${MEMORIES_MEM_LIMIT:-3g}
     ports:
       - "8900:8000"
     volumes:
@@ -40,9 +40,9 @@ services:
       # - MEMORY_TRIM_PERIODIC_SEC=5
       # Cloud Sync (optional - uncomment to enable)
       # - CLOUD_SYNC_ENABLED=true
-      # - CLOUD_SYNC_BUCKET=my-faiss-memory
+      # - CLOUD_SYNC_BUCKET=my-memories
       # - CLOUD_SYNC_REGION=us-east-1
-      # - CLOUD_SYNC_PREFIX=faiss-memory/
+      # - CLOUD_SYNC_PREFIX=memories/
       # - CLOUD_SYNC_ACCESS_KEY=AKIA...
       # - CLOUD_SYNC_SECRET_KEY=...
       # - CLOUD_SYNC_ENDPOINT=  # Optional: for MinIO, B2, etc.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# FAISS Memory Architecture
+# Memories Architecture
 
 This document describes the runtime architecture of `memories` and the reasoning behind the main component boundaries.
 
@@ -6,14 +6,14 @@ This document describes the runtime architecture of `memories` and the reasoning
 
 ## 1) System Overview
 
-FAISS Memory is a local-first semantic memory service for AI assistants. It exposes:
+Memories is a local-first semantic memory service for AI assistants. It exposes:
 
 - HTTP API (`app.py`) for direct integration
 - MCP wrapper (`mcp-server/index.js`) for MCP-capable clients
 
 Core storage and retrieval are handled by `MemoryEngine` (`memory_engine.py`) using:
 
-- vector similarity search (FAISS `IndexFlatIP`)
+- vector similarity search (Memories `IndexFlatIP`)
 - lexical ranking (BM25)
 - reciprocal-rank fusion (RRF) for hybrid search
 
@@ -23,7 +23,7 @@ Core storage and retrieval are handled by `MemoryEngine` (`memory_engine.py`) us
 Client (HTTP or MCP)
   -> FastAPI API (app.py)
   -> MemoryEngine (memory_engine.py)
-  -> ONNX Embedder (onnx_embedder.py) + FAISS + BM25
+  -> ONNX Embedder (onnx_embedder.py) + Memories + BM25
   -> Persistent files (/data/index.faiss, /data/metadata.json, /data/backups)
 ```
 
@@ -39,7 +39,7 @@ Client (HTTP or MCP)
 
 ### `memory_engine.py` (stateful core)
 
-- In-memory FAISS index and metadata lifecycle
+- In-memory Memories index and metadata lifecycle
 - CRUD operations and index rebuilds
 - Hybrid search (vector + BM25)
 - Backup/restore and optional cloud sync hooks
@@ -83,7 +83,7 @@ This prioritizes recoverability and correctness over maximal write throughput.
 ### Search (`POST /search`)
 
 1. Embed query via ONNX model
-2. Vector search over FAISS index
+2. Vector search over Memories index
 3. Optional BM25 rank over tokenized corpus
 4. Fuse with RRF and return top-k results
 

--- a/docs/benchmarks/2026-02-17-memory-reclamation.md
+++ b/docs/benchmarks/2026-02-17-memory-reclamation.md
@@ -5,7 +5,7 @@ Goal: verify that memory usage trends down after extraction bursts instead of st
 
 ## Setup
 
-- Image: `faiss-memory:codex-memtrim`
+- Image: `memories:codex-memtrim`
 - Two containers, same code, only one config difference:
   - `faiss-mem-notrim`: `MEMORY_TRIM_ENABLED=false`
   - `faiss-mem-trim`: `MEMORY_TRIM_ENABLED=true` + `MEMORY_TRIM_COOLDOWN_SEC=1`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,6 +1,6 @@
 # Engineering Decisions and Tradeoffs
 
-This document captures key architecture decisions for FAISS Memory and the tradeoffs behind each one.
+This document captures key architecture decisions for Memories and the tradeoffs behind each one.
 
 ---
 
@@ -16,7 +16,7 @@ This document captures key architecture decisions for FAISS Memory and the trade
   - custom embedder wrapper adds maintenance surface
   - less out-of-the-box flexibility than full PyTorch stack
 
-## D2: Use FAISS `IndexFlatIP` for Vector Search
+## D2: Use Memories `IndexFlatIP` for Vector Search
 
 - Status: accepted
 - Decision: use exact inner-product search with normalized embeddings.
@@ -40,7 +40,7 @@ This document captures key architecture decisions for FAISS Memory and the trade
   - extra compute and index maintenance (BM25 rebuilds on writes)
   - introduces fusion parameters to tune
 
-## D4: Keep Metadata in JSON Alongside FAISS Index
+## D4: Keep Metadata in JSON Alongside Memories Index
 
 - Status: accepted
 - Decision: persist metadata in `metadata.json` and vectors in `index.faiss`.

--- a/docs/plans/2026-02-17-memories-hard-cutover-design.md
+++ b/docs/plans/2026-02-17-memories-hard-cutover-design.md
@@ -6,101 +6,104 @@
 
 ## Context
 
-The codebase currently exposes mixed identity: product name "FAISS Memory", runtime service name `faiss-memory`, env vars `FAISS_*`, and integration docs/scripts built around those names. The project objective for this cycle is a hard cutover to a single external identity: **Memories**.
+The codebase still contains legacy naming across runtime identity strings, environment variables, deployment labels, and integration docs/scripts. This cycle standardizes all external naming to **Memories**.
 
 ## Goals
 
-1. Rename user-facing and operational identity to **Memories** across runtime, MCP, Docker, integrations, and docs.
-2. Use `MEMORIES_*` environment variable names as the only supported names.
-3. Rename deployment and cloud-backup defaults from `faiss-memory*` to `memories*`.
-4. Keep existing API route paths and request/response schemas stable except identity strings.
-5. Ship as PR only (no merge in this session).
+1. Standardize user-facing and operational identity to **Memories** across runtime, MCP, Docker, integrations, scripts, and docs.
+2. Use `MEMORIES_*` environment variables as the only documented and supported env naming.
+3. Align cloud-backup defaults to `memories*` naming.
+4. Keep existing API routes and payloads stable except identity strings.
+5. Ship as PR-only work (no merge in this session).
 
 ## Non-Goals
 
-1. No backend-engine replacement in this phase (FAISS internals stay as implementation detail).
-2. No queueing/sharding/stable-ID architecture changes in this phase.
-3. No dedicated migration/compatibility layer for old `FAISS_*` configs.
+1. No backend engine replacement in this phase.
+2. No scale architecture changes in this phase (queueing, sharding, stable IDs).
+3. No compatibility aliases for legacy names.
 
 ## Design Summary
 
-### 1) Runtime/API identity
+### Runtime/API
 
-Update runtime identity strings in:
+Files:
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/app.py`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/memory_engine.py`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/runtime_memory.py`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/cloud_sync.py`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/onnx_embedder.py`
 
 Changes:
-- logger namespaces: `faiss-memory*` -> `memories*`
-- FastAPI title: `FAISS Memory API` -> `Memories API`
-- `/health` service field: `faiss-memory` -> `memories`
+- logger namespaces standardized to `memories*`
+- API title standardized to `Memories API`
+- `/health` service value standardized to `memories`
+- cloud sync default prefix standardized to `memories/`
 
-### 2) MCP identity and env surface
+### MCP and package identity
 
-Update:
+Files:
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/index.js`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/package.json`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/package-lock.json`
 
 Changes:
-- server name: `faiss-memory` -> `memories`
-- env reads: `FAISS_URL`, `FAISS_API_KEY` -> `MEMORIES_URL`, `MEMORIES_API_KEY`
-- package name `faiss-memory-mcp` -> `memories-mcp`
+- MCP server identity standardized to `memories`
+- MCP env names standardized to `MEMORIES_URL` and `MEMORIES_API_KEY`
+- MCP package name standardized to `memories-mcp`
 
-### 3) Deployment naming
+### Deployment and ops scripts
 
-Update:
+Files:
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docker-compose.yml`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docker-compose.snippet.yml`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/scripts/backup.sh`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/scripts/install-cron.sh`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/scripts/backup-gdrive.sh`
 
 Changes:
-- service/container/image: `faiss-memory` -> `memories`
-- compose tunables: `FAISS_IMAGE_TARGET`, `FAISS_MEM_LIMIT` -> `MEMORIES_IMAGE_TARGET`, `MEMORIES_MEM_LIMIT`
-- comments/examples aligned to Memories naming
+- service/container/image standardized to `memories`
+- compose knobs standardized to `MEMORIES_IMAGE_TARGET` and `MEMORIES_MEM_LIMIT`
+- backup script env names standardized to `MEMORIES_*`
+- backup directory/folder defaults standardized to `memories*`
 
-### 4) Integrations and docs
+### Docs and integrations
 
-Update all docs and scripts under:
+Files:
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/README.md`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/PROJECT.md`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/GETTING_STARTED.md`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/CLOUD_SYNC_README.md`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/CLOUD_SYNC_DESIGN.md`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docs/`
 - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/`
+- `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/webui/index.html`
 
 Changes:
-- product references `FAISS Memory` -> `Memories`
-- env references `FAISS_*` -> `MEMORIES_*`
-- service key names and command examples `faiss-memory` -> `memories`
-- helper function names using `_faiss` renamed to `_memories` where practical
-
-### 5) Cloud-backup defaults
-
-Update cloud default labels/prefix examples from `faiss-memory` to `memories`, including any tested defaults and docs references.
+- branding standardized to `Memories`
+- examples standardized to `MEMORIES_*` env names
+- commands standardized to `memories` service/image/container references
 
 ## Risks
 
-1. Existing external configs using old names fail until manually updated.
-2. Operators with old cloud prefix/folder names must update config to discover new snapshots.
-3. Large search/replace may unintentionally alter historical/reference text if not reviewed.
+1. External configs still using legacy names will fail until updated.
+2. Operators using legacy backup prefixes/folder names must update settings.
+3. Large text substitutions can introduce accidental wording regressions.
 
 ## Risk Controls
 
-1. Keep endpoint paths unchanged.
+1. Keep API routes unchanged.
 2. Run full test suite after rename.
-3. Grep audit for leftover `FAISS_*`/`faiss-memory`/`FAISS Memory` references and intentionally keep only low-level technical internals (`import faiss`, `index.faiss`).
+3. Perform grep audit for legacy naming leftovers and manually review key docs/scripts.
 
 ## Validation Plan
 
-1. Unit/integration tests: `python -m pytest -q`
-2. Config tests still passing with renamed compose settings.
-3. Spot checks:
-   - `/health` returns `service: "memories"`
-   - MCP uses `MEMORIES_URL` / `MEMORIES_API_KEY`
-   - integration hooks install and run with `MEMORIES_*` vars.
+1. Run targeted red/green tests for compose/health/cloud naming.
+2. Run full suite: `python -m pytest -q`.
+3. Grep audit ensures no remaining legacy naming references.
 
 ## Implementation Sequence
 
-1. Add/adjust tests for rename expectations (TDD red).
-2. Apply runtime + MCP + compose + integrations/doc updates (green).
-3. Re-run full tests and targeted grep audits.
-4. Commit on feature branch and prepare PR summary.
+1. Write failing tests for new naming expectations.
+2. Update runtime, MCP, compose, and cloud defaults to new names.
+3. Rename integrations/docs/scripts/UI references.
+4. Run full verification and prepare PR summary.

--- a/docs/plans/2026-02-17-memories-hard-cutover.md
+++ b/docs/plans/2026-02-17-memories-hard-cutover.md
@@ -2,148 +2,68 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Hard-cut over external identity from FAISS naming to Memories naming across runtime, deployment, MCP, integrations, and docs.
+**Goal:** Hard-cut over all external naming to Memories naming across runtime, deployment, MCP, integrations, docs, and ops scripts.
 
-**Architecture:** Keep API route behavior stable while changing external naming surfaces (`FAISS_*` -> `MEMORIES_*`, `faiss-memory` -> `memories`, `FAISS Memory` -> `Memories`). Use test-first edits for behavioral assertions and a controlled rename pass for docs/integration surfaces.
+**Architecture:** Keep API behavior stable while standardizing naming surfaces to `Memories` and `MEMORIES_*`. Use test-first verification for behavior assertions and controlled rename passes for docs/scripts/integrations.
 
-**Tech Stack:** Python (FastAPI, pytest), Node (MCP server), Docker Compose, shell hooks, Markdown docs.
+**Tech Stack:** Python (FastAPI, pytest), Node (MCP server), Docker Compose, shell scripts, Markdown docs.
 
 ---
 
-### Task 1: Add Failing Tests for New Naming Surface
+### Task 1: Add Failing Tests for Naming Expectations
 
 **Files:**
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/tests/test_container_config.py`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/tests/test_metrics_api.py`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/tests/test_cloud_sync.py`
 
-**Step 1: Write failing test expectations for Memories naming**
-- Update assertions to require `memories` service/image naming and `MEMORIES_*` compose vars.
-- Add/adjust health assertion to require `/health` response `service == "memories"`.
-- Update cloud sync default-prefix expectations from `faiss-memory/` to `memories/`.
+**Steps:**
+1. Update tests to require `memories` compose identity and `MEMORIES_*` config names.
+2. Add health assertion for `service == "memories"`.
+3. Update cloud prefix default expectation to `memories/`.
+4. Run target tests and confirm RED.
 
-**Step 2: Run tests to verify RED state**
-Run:
-```bash
-/Users/dk/projects/memories/.venv/bin/python -m pytest -q tests/test_container_config.py tests/test_metrics_api.py tests/test_cloud_sync.py
-```
-Expected:
-- Failures showing old FAISS naming still present.
-
-**Step 3: Commit test-only RED state (optional if policy allows local red commit)**
-```bash
-git add tests/test_container_config.py tests/test_metrics_api.py tests/test_cloud_sync.py
-git commit -m "test: require Memories naming across config and health"
-```
-
-### Task 2: Implement Runtime/MCP/Compose Renames (Green)
+### Task 2: Implement Runtime/MCP/Compose/Cloud Renames
 
 **Files:**
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/app.py`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/memory_engine.py`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/runtime_memory.py`
+- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/cloud_sync.py`
+- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/onnx_embedder.py`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/index.js`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/package.json`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/mcp-server/package-lock.json`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docker-compose.yml`
 - Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docker-compose.snippet.yml`
 
-**Step 1: Update runtime identity fields and loggers**
-- `FAISS Memory API` -> `Memories API`
-- health payload `service: "memories"`
-- logger namespace strings `faiss-memory*` -> `memories*`
+**Steps:**
+1. Standardize runtime identity strings/loggers.
+2. Standardize MCP env names and server/package identity.
+3. Standardize compose service/image/container and resource vars.
+4. Re-run target tests and confirm GREEN.
 
-**Step 2: Update MCP surface**
-- env vars in MCP server to `MEMORIES_URL` and `MEMORIES_API_KEY`
-- server name and package metadata to `memories`
-
-**Step 3: Update Docker compose naming**
-- service/image/container `memories`
-- `MEMORIES_IMAGE_TARGET` and `MEMORIES_MEM_LIMIT` variables
-
-**Step 4: Re-run target tests (Green)**
-Run:
-```bash
-/Users/dk/projects/memories/.venv/bin/python -m pytest -q tests/test_container_config.py tests/test_metrics_api.py tests/test_cloud_sync.py
-```
-Expected:
-- All targeted tests pass.
-
-**Step 5: Commit implementation**
-```bash
-git add app.py memory_engine.py runtime_memory.py mcp-server/index.js mcp-server/package.json mcp-server/package-lock.json docker-compose.yml docker-compose.snippet.yml tests/test_container_config.py tests/test_metrics_api.py tests/test_cloud_sync.py
-git commit -m "feat: hard-cutover runtime and deploy naming to Memories"
-```
-
-### Task 3: Rename Integrations and Docs, then Full Verification
+### Task 3: Rename Integrations, Docs, Scripts, and UI Labels
 
 **Files:**
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/README.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/PROJECT.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docs/architecture.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docs/decisions.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docs/benchmarks/2026-02-17-memory-reclamation.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/QUICKSTART-LLM.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/openclaw-skill.md`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/install.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/memory-recall.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/memory-query.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/memory-extract.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/memory-flush.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/memory-commit.sh`
-- Modify: `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/claude-code/hooks/hooks.json`
+- Modify docs and integrations under:
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/README.md`
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/PROJECT.md`
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/docs/`
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/integrations/`
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/scripts/`
+  - `/Users/dk/projects/memories/.worktrees/memories-hard-cutover/webui/index.html`
 
-**Step 1: Rename all user-facing FAISS naming references to Memories naming**
-- Product label strings.
-- Env var names and shell variable defaults.
-- Docker service names and command snippets.
-- OpenClaw helper names suffixed `_memories` where practical.
+**Steps:**
+1. Standardize all user-facing labels to `Memories`.
+2. Standardize env examples to `MEMORIES_*`.
+3. Standardize command examples to `memories` service names.
+4. Run grep audit for leftover legacy naming tokens.
 
-**Step 2: Grep audit for stale external naming**
-Run:
-```bash
-rg -n "FAISS_|FAISS Memory|faiss-memory" README.md PROJECT.md docs integrations mcp-server docker-compose.yml docker-compose.snippet.yml app.py
-```
-Expected:
-- No external surface leftovers except intentionally retained low-level technical internals (e.g. `import faiss`, `index.faiss`).
+### Task 4: Verification and PR Preparation
 
-**Step 3: Full verification**
-Run:
-```bash
-/Users/dk/projects/memories/.venv/bin/python -m pytest -q
-```
-Expected:
-- Full test suite passes.
-
-**Step 4: Commit docs/integration cutover**
-```bash
-git add README.md PROJECT.md docs integrations
-git commit -m "docs: rename user-facing identity and env examples to Memories"
-```
-
-### Task 4: PR Preparation (No Merge)
-
-**Files:**
-- No code changes required; may update notes in plan/design docs if needed.
-
-**Step 1: Show branch diff summary**
-Run:
-```bash
-git status --short
-git log --oneline --decorate -n 8
-git diff --stat origin/codex/memory-rss-hardening...HEAD
-```
-
-**Step 2: Request code review**
-- Use superpowers `requesting-code-review` workflow against the branch range.
-
-**Step 3: Prepare PR text**
-Include:
-- Summary of hard cutover scope
-- Explicit no-compatibility decision
-- Verification commands run + outcomes
-- Known operator actions (update `MEMORIES_*`, service names, cloud prefix defaults)
-
-**Step 4: Stop at PR-ready state**
-- Do not merge.
+**Steps:**
+1. Run full test suite and capture output.
+2. Review git diff/stat for consistency.
+3. Keep branch in PR-ready state.
+4. Do not merge.

--- a/integrations/claude-code.md
+++ b/integrations/claude-code.md
@@ -1,19 +1,19 @@
 # Claude Code Integration
 
-> Use FAISS Memory with [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) for persistent semantic memory across sessions.
+> Use Memories with [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) for persistent semantic memory across sessions.
 
 ---
 
 ## Quick Start
 
-### 1. Ensure FAISS Memory is Running
+### 1. Ensure Memories is Running
 
 ```bash
 # Check service health
 curl http://localhost:8900/health
 
 # If not running, start it:
-cd /path/to/faiss-memory
+cd /path/to/memories
 docker compose up -d
 ```
 
@@ -89,12 +89,12 @@ npm install
 // ~/.claude/settings.json
 {
   "mcpServers": {
-    "faiss-memory": {
+    "memories": {
       "command": "node",
       "args": ["/path/to/memories/mcp-server/index.js"],
       "env": {
-        "FAISS_URL": "http://localhost:8900",
-        "FAISS_API_KEY": "your-api-key-here"
+        "MEMORIES_URL": "http://localhost:8900",
+        "MEMORIES_API_KEY": "your-api-key-here"
       }
     }
   }
@@ -120,7 +120,7 @@ npm install
 
 ```bash
 # Source the helper functions
-source ~/.openclaw/skills/faiss-memory/helpers.sh
+source ~/.openclaw/skills/memories/helpers.sh
 
 # Claude Code can call these functions
 fmem-search "authentication patterns" 5
@@ -345,7 +345,7 @@ Then review the code against those standards."
 Add to `~/.bashrc` or `~/.zshrc`:
 
 ```bash
-# FAISS Memory shortcuts
+# Memories shortcuts
 alias fmem-search='curl -X POST http://localhost:8900/search -H "Content-Type: application/json" -d'
 alias fmem-add='curl -X POST http://localhost:8900/memory/add -H "Content-Type: application/json" -d'
 alias fmem-novel='curl -X POST http://localhost:8900/memory/is-novel -H "Content-Type: application/json" -d'
@@ -396,10 +396,10 @@ Source in your shell: `source ~/.config/claude/tools.sh`
 **Solution:**
 ```bash
 # Check if service is running
-docker ps | grep faiss-memory
+docker ps | grep memories
 
 # If not running:
-cd /path/to/faiss-memory
+cd /path/to/memories
 docker compose up -d
 
 # Check health
@@ -425,7 +425,7 @@ curl -X POST http://localhost:8900/memory/add \
 This usually means MCP is not loaded or config path is wrong.
 
 ```bash
-# 1) Confirm MCP config contains the faiss-memory server
+# 1) Confirm MCP config contains the memories server
 cat ~/.claude/settings.json
 
 # 2) Verify node deps exist
@@ -491,7 +491,7 @@ Adjust novelty detection sensitivity:
 
 ## Integration Checklist
 
-- [ ] FAISS Memory service running (`docker ps | grep faiss-memory`)
+- [ ] Memories service running (`docker ps | grep memories`)
 - [ ] Health check passing (`curl http://localhost:8900/health`)
 - [ ] Initial memories loaded (project docs, standards, decisions)
 - [ ] Tested search with sample query
@@ -514,7 +514,7 @@ Adjust novelty detection sensitivity:
 
 ## Resources
 
-- 📖 [FAISS Memory API Docs](../docs/API.md)
+- 📖 [Memories API Docs](../docs/API.md)
 - 💡 [Example Prompts](../examples/claude-code/)
 - 🐛 [Troubleshooting](../docs/TROUBLESHOOTING.md)
 - 🚀 [Advanced Usage](../docs/ADVANCED.md)

--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -4,7 +4,7 @@
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "${FAISS_HOOKS_DIR:-~/.claude/hooks/memory}/memory-recall.sh",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-recall.sh",
         "timeout": 5
       }]
     }],
@@ -12,7 +12,7 @@
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "${FAISS_HOOKS_DIR:-~/.claude/hooks/memory}/memory-query.sh",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-query.sh",
         "timeout": 3
       }]
     }],
@@ -20,7 +20,7 @@
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "${FAISS_HOOKS_DIR:-~/.claude/hooks/memory}/memory-extract.sh",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-extract.sh",
         "timeout": 30
       }]
     }],
@@ -28,7 +28,7 @@
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "${FAISS_HOOKS_DIR:-~/.claude/hooks/memory}/memory-flush.sh",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-flush.sh",
         "timeout": 30
       }]
     }],
@@ -36,7 +36,7 @@
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "${FAISS_HOOKS_DIR:-~/.claude/hooks/memory}/memory-commit.sh",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-commit.sh",
         "timeout": 30
       }]
     }]

--- a/integrations/claude-code/hooks/memory-commit.sh
+++ b/integrations/claude-code/hooks/memory-commit.sh
@@ -4,8 +4,8 @@
 
 set -euo pipefail
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-FAISS_API_KEY="${FAISS_API_KEY:-}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
 
 INPUT=$(cat)
 MESSAGES=$(echo "$INPUT" | jq -r '.messages // empty')
@@ -16,8 +16,8 @@ fi
 CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
 PROJECT=$(basename "$CWD")
 
-curl -sf -X POST "$FAISS_URL/memory/extract" \
+curl -sf -X POST "$MEMORIES_URL/memory/extract" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: $FAISS_API_KEY" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "{\"messages\": $(echo "$MESSAGES" | jq -Rs), \"source\": \"claude-code/$PROJECT\", \"context\": \"session_end\"}" \
   > /dev/null 2>&1 || true

--- a/integrations/claude-code/hooks/memory-extract.sh
+++ b/integrations/claude-code/hooks/memory-extract.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # memory-extract.sh — Stop hook (async)
 # Extracts facts from the last exchange and stores via AUDN pipeline.
-# Requires FAISS service with extraction enabled (EXTRACT_PROVIDER set).
+# Requires Memories service with extraction enabled (EXTRACT_PROVIDER set).
 
 set -euo pipefail
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-FAISS_API_KEY="${FAISS_API_KEY:-}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
 
 INPUT=$(cat)
 STOP_REASON=$(echo "$INPUT" | jq -r '.stop_reason // "end_turn"')
@@ -25,8 +25,8 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
 PROJECT=$(basename "$CWD")
 
 # POST to extraction endpoint (fire-and-forget, async hook)
-curl -sf -X POST "$FAISS_URL/memory/extract" \
+curl -sf -X POST "$MEMORIES_URL/memory/extract" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: $FAISS_API_KEY" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "{\"messages\": $(echo "$MESSAGES" | jq -Rs), \"source\": \"claude-code/$PROJECT\", \"context\": \"stop\"}" \
   > /dev/null 2>&1 || true

--- a/integrations/claude-code/hooks/memory-flush.sh
+++ b/integrations/claude-code/hooks/memory-flush.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-FAISS_API_KEY="${FAISS_API_KEY:-}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
 
 INPUT=$(cat)
 MESSAGES=$(echo "$INPUT" | jq -r '.messages // empty')
@@ -17,8 +17,8 @@ fi
 CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
 PROJECT=$(basename "$CWD")
 
-curl -sf -X POST "$FAISS_URL/memory/extract" \
+curl -sf -X POST "$MEMORIES_URL/memory/extract" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: $FAISS_API_KEY" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "{\"messages\": $(echo "$MESSAGES" | jq -Rs), \"source\": \"claude-code/$PROJECT\", \"context\": \"pre_compact\"}" \
   > /dev/null 2>&1 || true

--- a/integrations/claude-code/hooks/memory-query.sh
+++ b/integrations/claude-code/hooks/memory-query.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # memory-query.sh — UserPromptSubmit hook
-# Searches FAISS for memories relevant to the current prompt.
+# Searches Memories for memories relevant to the current prompt.
 # Sync hook: blocks until done, injects additionalContext.
 
 set -euo pipefail
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-FAISS_API_KEY="${FAISS_API_KEY:-}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
@@ -16,9 +16,9 @@ if [ ${#PROMPT} -lt 20 ]; then
   exit 0
 fi
 
-RESULTS=$(curl -sf -X POST "$FAISS_URL/search" \
+RESULTS=$(curl -sf -X POST "$MEMORIES_URL/search" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: $FAISS_API_KEY" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "{\"query\": $(echo "$PROMPT" | jq -Rs), \"k\": 5, \"hybrid\": true, \"threshold\": 0.4}" \
   2>/dev/null \
   | jq -r '[.results[]] | .[0:5] | map("- [\(.source)] \(.text)") | join("\n")' 2>/dev/null) || true

--- a/integrations/claude-code/hooks/memory-recall.sh
+++ b/integrations/claude-code/hooks/memory-recall.sh
@@ -5,8 +5,8 @@
 
 set -euo pipefail
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-FAISS_API_KEY="${FAISS_API_KEY:-}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
@@ -16,9 +16,9 @@ fi
 
 PROJECT=$(basename "$CWD")
 
-RESULTS=$(curl -sf -X POST "$FAISS_URL/search" \
+RESULTS=$(curl -sf -X POST "$MEMORIES_URL/search" \
   -H "Content-Type: application/json" \
-  -H "X-API-Key: $FAISS_API_KEY" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "{\"query\": \"project $PROJECT conventions decisions patterns\", \"k\": 10, \"hybrid\": true}" \
   2>/dev/null \
   | jq -r '[.results[]] | .[0:8] | map("- \(.text)") | join("\n")' 2>/dev/null) || true

--- a/integrations/claude-code/install.sh
+++ b/integrations/claude-code/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# install.sh — installer for FAISS Memory automatic integrations
+# install.sh — installer for Memories automatic integrations
 # Usage: ./install.sh [--auto] [--claude] [--codex] [--openclaw] [--uninstall] [--dry-run]
 set -euo pipefail
 
@@ -25,7 +25,7 @@ DRY_RUN=false
 
 usage() {
   cat <<'EOF'
-FAISS Memory installer
+Memories installer
 
 Usage:
   ./integrations/claude-code/install.sh [options]
@@ -145,7 +145,7 @@ else
 fi
 
 echo ""
-echo -e "${BLUE}FAISS Memory — Automatic Memory Layer Setup${NC}"
+echo -e "${BLUE}Memories — Automatic Memory Layer Setup${NC}"
 echo -e "${BLUE}============================================${NC}"
 echo -e "Targets: ${GREEN}$TARGETS_CSV${NC}"
 echo ""
@@ -170,30 +170,30 @@ if [ "$UNINSTALL" = true ]; then
 
   if [ "$TARGET_CLAUDE" = true ]; then
     remove_target "Claude hooks" "$HOME/.claude/hooks/memory"
-    echo "  Manual cleanup: remove FAISS hook entries from $HOME/.claude/settings.json"
+    echo "  Manual cleanup: remove Memories hook entries from $HOME/.claude/settings.json"
   fi
 
   if [ "$TARGET_CODEX" = true ]; then
     remove_target "Codex hooks" "$HOME/.codex/hooks/memory"
-    echo "  Manual cleanup: remove FAISS hook entries from $HOME/.codex/settings.json"
+    echo "  Manual cleanup: remove Memories hook entries from $HOME/.codex/settings.json"
   fi
 
   if [ "$TARGET_OPENCLAW" = true ]; then
-    remove_target "OpenClaw skill" "$HOME/.openclaw/skills/faiss-memory"
+    remove_target "OpenClaw skill" "$HOME/.openclaw/skills/memories"
   fi
 
   echo ""
-  echo "Manual cleanup (optional): remove FAISS_* and EXTRACT_* vars from $SHELL_PROFILE"
+  echo "Manual cleanup (optional): remove MEMORIES_* and EXTRACT_* vars from $SHELL_PROFILE"
   exit 0
 fi
 
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
 
-echo -e "[1/4] Checking FAISS service at ${BLUE}$FAISS_URL${NC}..."
-HEALTH=$(curl -sf "$FAISS_URL/health" 2>/dev/null || echo "FAIL")
+echo -e "[1/4] Checking Memories service at ${BLUE}$MEMORIES_URL${NC}..."
+HEALTH=$(curl -sf "$MEMORIES_URL/health" 2>/dev/null || echo "FAIL")
 if [ "$HEALTH" = "FAIL" ]; then
-  echo -e "  ${RED}[FAIL]${NC} FAISS service not reachable at $FAISS_URL"
-  echo "  Start it with: docker compose up -d faiss-memory"
+  echo -e "  ${RED}[FAIL]${NC} Memories service not reachable at $MEMORIES_URL"
+  echo "  Start it with: docker compose up -d memories"
   exit 1
 fi
 TOTAL=$(echo "$HEALTH" | jq -r '.total_memories // 0')
@@ -307,7 +307,7 @@ install_hooks_target() {
 }
 
 install_openclaw_target() {
-  local skill_dir="$HOME/.openclaw/skills/faiss-memory"
+  local skill_dir="$HOME/.openclaw/skills/memories"
   mkdir -p "$skill_dir"
   cp "$OPENCLAW_SKILL_SRC" "$skill_dir/SKILL.md"
   echo -e "  ${GREEN}[OK]${NC} Installed OpenClaw skill: $skill_dir/SKILL.md"
@@ -339,11 +339,11 @@ add_env_if_missing() {
   fi
 }
 
-add_env_if_missing "FAISS_URL" "$FAISS_URL"
+add_env_if_missing "MEMORIES_URL" "$MEMORIES_URL"
 
-FAISS_API_KEY="${FAISS_API_KEY:-}"
-if [ -n "$FAISS_API_KEY" ]; then
-  add_env_if_missing "FAISS_API_KEY" "$FAISS_API_KEY"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+if [ -n "$MEMORIES_API_KEY" ]; then
+  add_env_if_missing "MEMORIES_API_KEY" "$MEMORIES_API_KEY"
 fi
 
 if [ -n "$EXTRACT_PROVIDER" ]; then

--- a/integrations/openclaw-skill.md
+++ b/integrations/openclaw-skill.md
@@ -1,7 +1,7 @@
 ---
-name: faiss-memory
+name: memories
 version: 2.0.0
-description: FAISS-based semantic memory search via Docker service. Fast (<20ms), local, with hybrid BM25+vector search, auto-dedup, and automatic backups.
+description: Memories-based semantic memory search via Docker service. Fast (<20ms), local, with hybrid BM25+vector search, auto-dedup, and automatic backups.
 metadata:
   clawdbot:
     emoji: "🧠"
@@ -11,14 +11,14 @@ metadata:
         - jq
 ---
 
-# FAISS Memory
+# Memories
 
-Local semantic memory using FAISS vector search + BM25 hybrid retrieval (Docker service).
+Local semantic memory using Memories vector search + BM25 hybrid retrieval (Docker service).
 
 ## Features
 
 - **Fast**: <20ms semantic searches
-- **Hybrid**: BM25 keyword + FAISS vector search (RRF fusion)
+- **Hybrid**: BM25 keyword + Memories vector search (RRF fusion)
 - **Local**: 100% on-device, no external APIs
 - **Secure**: Localhost-only Docker service
 - **Backed up**: Automatic backups before operations
@@ -27,16 +27,16 @@ Local semantic memory using FAISS vector search + BM25 hybrid retrieval (Docker 
 
 ## Prerequisites
 
-- Docker service running: `docker ps | grep faiss-memory`
-- If not running: `cd /path/to/memories && docker compose up -d faiss-memory`
-- `FAISS_API_KEY` env var must be set (loaded from shell profile)
+- Docker service running: `docker ps | grep memories`
+- If not running: `cd /path/to/memories && docker compose up -d memories`
+- `MEMORIES_API_KEY` env var must be set (loaded from shell profile)
 
 ## Commands
 
 ### Search Memories (Hybrid)
 
 ```bash
-function memory_search_faiss() {
+function memory_search_memories() {
     local query="$1"
     local k="${2:-5}"
     local threshold="${3:-0.0}"
@@ -52,22 +52,22 @@ function memory_search_faiss() {
 
     curl -s -X POST http://localhost:8900/search \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq -r '.results[] | "\(.similarity // .rrf_score | tonumber | . * 100 | floor)% | \(.source): \(.text[:200])"'
 }
 
 # Usage
-memory_search_faiss "database preferences"
-memory_search_faiss "database preferences" 3       # Top 3 results
-memory_search_faiss "database preferences" 5 0.7   # Min 70% similarity
-memory_search_faiss "exact keyword match" 5 0 true # Hybrid mode (default)
+memory_search_memories "database preferences"
+memory_search_memories "database preferences" 3       # Top 3 results
+memory_search_memories "database preferences" 5 0.7   # Min 70% similarity
+memory_search_memories "exact keyword match" 5 0 true # Hybrid mode (default)
 ```
 
 ### Add New Memory
 
 ```bash
-function memory_add_faiss() {
+function memory_add_memories() {
     local text="$1"
     local source="$2"
     local dedup="${3:-true}"
@@ -81,14 +81,14 @@ function memory_add_faiss() {
 
     curl -s -X POST http://localhost:8900/memory/add \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq -r '.message'
 }
 
 # Usage
-memory_add_faiss "Prefer Brave Search API" "technical.md:180"
-memory_add_faiss "New fact" "source.md" true  # auto-dedup (default)
+memory_add_memories "Prefer Brave Search API" "technical.md:180"
+memory_add_memories "New fact" "source.md" true  # auto-dedup (default)
 ```
 
 ### Check if Novel
@@ -107,7 +107,7 @@ function memory_is_novel() {
     local result
     result=$(curl -s -X POST http://localhost:8900/memory/is-novel \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload")
 
     local is_novel
@@ -130,21 +130,21 @@ memory_is_novel "New preference to check"
 ### Delete Memory
 
 ```bash
-function memory_delete_faiss() {
+function memory_delete_memories() {
     local id="$1"
     curl -s -X DELETE "http://localhost:8900/memory/$id" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
     | jq -r '.deleted_text // .detail'
 }
 
 # Usage
-memory_delete_faiss 42
+memory_delete_memories 42
 ```
 
 ### Delete by Source
 
 ```bash
-function memory_delete_source_faiss() {
+function memory_delete_source_memories() {
     local pattern="$1"
 
     local payload
@@ -152,20 +152,20 @@ function memory_delete_source_faiss() {
 
     curl -s -X POST http://localhost:8900/memory/delete-by-source \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq -r '"Deleted \(.deleted_count) memories"'
 }
 
 # Usage
-memory_delete_source_faiss "credentials"
-memory_delete_source_faiss "old-file.md"
+memory_delete_source_memories "credentials"
+memory_delete_source_memories "old-file.md"
 ```
 
 ### Browse Memories
 
 ```bash
-function memory_list_faiss() {
+function memory_list_memories() {
     local offset="${1:-0}"
     local limit="${2:-20}"
     local source="${3:-}"
@@ -175,24 +175,24 @@ function memory_list_faiss() {
         url="${url}&source=$source"
     fi
 
-    curl -s "$url" -H "X-API-Key: $FAISS_API_KEY" | jq -r '.memories[] | "[\(.id)] \(.source): \(.text[:120])"'
+    curl -s "$url" -H "X-API-Key: $MEMORIES_API_KEY" | jq -r '.memories[] | "[\(.id)] \(.source): \(.text[:120])"'
 }
 
 # Usage
-memory_list_faiss             # First 20
-memory_list_faiss 20 10       # Next 10
-memory_list_faiss 0 50 "lang" # Filter by source
+memory_list_memories             # First 20
+memory_list_memories 20 10       # Next 10
+memory_list_memories 0 50 "lang" # Filter by source
 ```
 
 ### Rebuild Index
 
 ```bash
 function memory_rebuild_index() {
-    echo "🔄 Rebuilding FAISS index from workspace files..."
+    echo "🔄 Rebuilding Memories index from workspace files..."
 
     curl -s -X POST http://localhost:8900/index/build \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d '{}' \
     | jq -r '"✅ \(.message)\n   Files: \(.files_processed)\n   Memories: \(.memories_added)\n   Backup: \(.backup_location)"'
 }
@@ -204,7 +204,7 @@ memory_rebuild_index
 ### Deduplicate
 
 ```bash
-function memory_dedup_faiss() {
+function memory_dedup_memories() {
     local dry_run="${1:-true}"
     local threshold="${2:-0.90}"
 
@@ -216,23 +216,23 @@ function memory_dedup_faiss() {
 
     curl -s -X POST http://localhost:8900/memory/deduplicate \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq '.'
 }
 
 # Usage
-memory_dedup_faiss true       # Dry run (preview)
-memory_dedup_faiss false      # Actually remove duplicates
-memory_dedup_faiss true 0.85  # Lower threshold = more aggressive
+memory_dedup_memories true       # Dry run (preview)
+memory_dedup_memories false      # Actually remove duplicates
+memory_dedup_memories true 0.85  # Lower threshold = more aggressive
 ```
 
 ### View Stats
 
 ```bash
 function memory_stats() {
-    curl -s http://localhost:8900/stats -H "X-API-Key: $FAISS_API_KEY" | jq '
-        "📊 FAISS Memory Stats",
+    curl -s http://localhost:8900/stats -H "X-API-Key: $MEMORIES_API_KEY" | jq '
+        "📊 Memories Stats",
         "━━━━━━━━━━━━━━━━━━━━━━",
         "Total memories: \(.total_memories)",
         "Dimensions: \(.dimension)",
@@ -251,7 +251,7 @@ memory_stats
 
 ```bash
 function memory_backups() {
-    curl -s http://localhost:8900/backups -H "X-API-Key: $FAISS_API_KEY" \
+    curl -s http://localhost:8900/backups -H "X-API-Key: $MEMORIES_API_KEY" \
     | jq -r '.backups[] | "\(.name)"'
 }
 
@@ -266,7 +266,7 @@ function memory_backup() {
     local prefix="${1:-manual}"
 
     curl -s -X POST "http://localhost:8900/backup?prefix=$prefix" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
     | jq -r '"✅ \(.message)\n   Location: \(.backup_path)"'
 }
 
@@ -286,7 +286,7 @@ function memory_restore() {
 
     curl -s -X POST http://localhost:8900/restore \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq -r '"✅ \(.message)\n   Memories: \(.total_memories)"'
 }
@@ -300,11 +300,11 @@ memory_restore "manual_20260213_120000"  # Restore specific backup
 
 ```bash
 function memory_health() {
-    curl -s http://localhost:8900/health -H "X-API-Key: $FAISS_API_KEY" | jq '
+    curl -s http://localhost:8900/health -H "X-API-Key: $MEMORIES_API_KEY" | jq '
         if .status == "ok" then
-            "✅ FAISS Memory: HEALTHY (v\(.version // "?"))\n   Memories: \(.total_memories)\n   Model: \(.model)"
+            "✅ Memories: HEALTHY (v\(.version // "?"))\n   Memories: \(.total_memories)\n   Model: \(.model)"
         else
-            "❌ FAISS Memory: UNHEALTHY"
+            "❌ Memories: UNHEALTHY"
         end
     ' -r
 }
@@ -318,7 +318,7 @@ memory_health
 Call this at the start of any task to load relevant project memories:
 
 ```bash
-function memory_recall_faiss() {
+function memory_recall_memories() {
     local project="${1:-$(basename "$PWD")}"
     local k="${2:-8}"
 
@@ -331,7 +331,7 @@ function memory_recall_faiss() {
     local results
     results=$(curl -s -X POST http://localhost:8900/search \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq -r '[.results[] | select(.similarity > 0.3)] | .[0:8] | map("- \(.text)") | join("\n")')
 
@@ -345,8 +345,8 @@ function memory_recall_faiss() {
 }
 
 # Usage — call at the start of every task
-memory_recall_faiss
-memory_recall_faiss "my-project" 10
+memory_recall_memories
+memory_recall_memories "my-project" 10
 ```
 
 ### Extract Facts from Conversation (Auto)
@@ -354,7 +354,7 @@ memory_recall_faiss "my-project" 10
 Call this after completing significant tasks to store new learnings:
 
 ```bash
-function memory_extract_faiss() {
+function memory_extract_memories() {
     local messages="$1"
     local source="${2:-openclaw/$(basename "$PWD")}"
     local context="${3:-stop}"
@@ -368,14 +368,14 @@ function memory_extract_faiss() {
 
     curl -s -X POST http://localhost:8900/memory/extract \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $FAISS_API_KEY" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
         -d "$payload" \
     | jq '.'
 }
 
 # Usage — call after completing tasks
-memory_extract_faiss "User: use drizzle\nAssistant: Good choice, switching from Prisma"
-memory_extract_faiss "conversation text" "openclaw/my-project" "session_end"
+memory_extract_memories "User: use drizzle\nAssistant: Good choice, switching from Prisma"
+memory_extract_memories "conversation text" "openclaw/my-project" "session_end"
 ```
 
 ## Typical Workflows
@@ -384,26 +384,26 @@ memory_extract_faiss "conversation text" "openclaw/my-project" "session_end"
 
 At the start of every task, recall relevant project context:
 ```bash
-memory_recall_faiss
+memory_recall_memories
 ```
 
 When you need to search for something specific:
 ```bash
-memory_search_faiss "your query" 5
+memory_search_memories "your query" 5
 ```
 
 ### After Task Completion
 
 Extract and store new learnings from the conversation:
 ```bash
-memory_extract_faiss "summary of conversation or key decisions"
+memory_extract_memories "summary of conversation or key decisions"
 ```
 
 ### Add Important Fact
 
 When storing new information (auto-dedup enabled by default):
 ```bash
-memory_add_faiss "New preference or fact" "MEMORY.md:100"
+memory_add_memories "New preference or fact" "MEMORY.md:100"
 ```
 
 ### Weekly Maintenance
@@ -411,8 +411,8 @@ memory_add_faiss "New preference or fact" "MEMORY.md:100"
 Rebuild index from updated files and deduplicate:
 ```bash
 memory_rebuild_index
-memory_dedup_faiss true   # Preview
-memory_dedup_faiss false  # Execute
+memory_dedup_memories true   # Preview
+memory_dedup_memories false  # Execute
 ```
 
 ### Before OpenClaw Upgrade
@@ -426,18 +426,18 @@ memory_backup "before_openclaw_upgrade_$(date +%Y%m%d)"
 
 During heartbeats, I can:
 
-1. **Extract new learnings** using `memory_extract_faiss` (preferred — sends conversation to the extract endpoint which handles fact extraction, novelty checking, and storage in one call)
-2. **Manual alternative**: Check novelty with `memory_is_novel`, then add if novel with `memory_add_faiss` (auto-dedup enabled)
-3. **Recall context** at task start with `memory_recall_faiss`
+1. **Extract new learnings** using `memory_extract_memories` (preferred — sends conversation to the extract endpoint which handles fact extraction, novelty checking, and storage in one call)
+2. **Manual alternative**: Check novelty with `memory_is_novel`, then add if novel with `memory_add_memories` (auto-dedup enabled)
+3. **Recall context** at task start with `memory_recall_memories`
 4. **Auto-backup** handled by service
 
 ## Troubleshooting
 
 ### Service not responding
 ```bash
-docker ps | grep faiss-memory
-docker logs -f faiss-memory
-cd /path/to/memories && docker compose restart faiss-memory
+docker ps | grep memories
+docker logs -f memories
+cd /path/to/memories && docker compose restart memories
 ```
 
 ### Empty search results

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "faiss-memory-mcp",
+  "name": "memories-mcp",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "faiss-memory-mcp",
+      "name": "memories-mcp",
       "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "faiss-memory-mcp",
+  "name": "memories-mcp",
   "version": "2.0.0",
-  "description": "MCP server for FAISS Memory — semantic search, add, delete, browse",
+  "description": "MCP server for Memories — semantic search, add, delete, browse",
   "type": "module",
   "main": "index.js",
   "scripts": {

--- a/memory_engine.py
+++ b/memory_engine.py
@@ -1,5 +1,5 @@
 """
-FAISS Memory Engine
+Memories Engine
 Local semantic search with hybrid BM25+vector retrieval, markdown-aware
 chunking, automatic backups, and concurrency safety.
 """
@@ -17,7 +17,7 @@ from typing import List, Dict, Any, Optional, Tuple
 from onnx_embedder import OnnxEmbedder
 from rank_bm25 import BM25Okapi
 
-logger = logging.getLogger("faiss-memory")
+logger = logging.getLogger("memories")
 
 # Cloud sync (optional dependency)
 try:
@@ -29,7 +29,7 @@ except ImportError:
 
 
 class MemoryEngine:
-    """FAISS-based semantic memory with hybrid search and backup support"""
+    """Memories engine with hybrid search and backup support"""
 
     def __init__(
         self,

--- a/onnx_embedder.py
+++ b/onnx_embedder.py
@@ -12,7 +12,7 @@ from typing import List, Union
 from huggingface_hub import hf_hub_download
 from tokenizers import Tokenizer
 
-logger = logging.getLogger("faiss-memory")
+logger = logging.getLogger("memories")
 
 # Map of short names to HuggingFace repo IDs
 MODEL_MAP = {

--- a/runtime_memory.py
+++ b/runtime_memory.py
@@ -10,7 +10,7 @@ import threading
 import time
 from typing import Callable, Optional
 
-logger = logging.getLogger("faiss-memory.runtime")
+logger = logging.getLogger("memories.runtime")
 
 
 def _load_malloc_trim() -> Optional[Callable[[int], int]]:

--- a/scripts/backup-gdrive.sh
+++ b/scripts/backup-gdrive.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# FAISS Memory - Off-site Backup to Google Drive (Optional)
+# Memories - Off-site Backup to Google Drive (Optional)
 # Uploads the latest snapshot hourly and maintains 7-day retention
 #
 # Usage:
@@ -17,8 +17,8 @@
 #
 # Environment:
 #   GDRIVE_ACCOUNT       - Google account email (required)
-#   GDRIVE_FOLDER_NAME   - Drive folder name (default: faiss-memory-backups)
-#   BACKUP_DIR           - Local backup dir (default: ~/backups/faiss-memory)
+#   GDRIVE_FOLDER_NAME   - Drive folder name (default: memories-backups)
+#   BACKUP_DIR           - Local backup dir (default: ~/backups/memories)
 #   UPLOAD_INTERVAL_MIN  - Min minutes between uploads (default: 55)
 #   GDRIVE_RETENTION_DAYS - Days to keep on Drive (default: 7)
 #
@@ -32,10 +32,10 @@ export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
 [ -f "$HOME/.zshrc" ] && source "$HOME/.zshrc" 2>/dev/null || true
 
 # Configuration (all overridable via env vars)
-BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/faiss-memory}"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/memories}"
 LOG_FILE="$BACKUP_DIR/gdrive.log"
 GDRIVE_ACCOUNT="${GDRIVE_ACCOUNT}"
-GDRIVE_FOLDER_NAME="${GDRIVE_FOLDER_NAME:-faiss-memory-backups}"
+GDRIVE_FOLDER_NAME="${GDRIVE_FOLDER_NAME:-memories-backups}"
 FOLDER_ID_FILE="$BACKUP_DIR/.gdrive_folder_id"
 LAST_UPLOAD_FILE="$BACKUP_DIR/.gdrive_last_upload"
 UPLOAD_INTERVAL_MIN="${UPLOAD_INTERVAL_MIN:-55}"
@@ -270,7 +270,7 @@ for f in files:
 
 # Setup: create folder and test auth
 setup() {
-    log "INFO" "=== Setting up Google Drive backup for FAISS Memory ==="
+    log "INFO" "=== Setting up Google Drive backup for Memories ==="
 
     # Test auth
     if ! gog drive ls --account="$GDRIVE_ACCOUNT" --json --results-only 2>/dev/null | head -1 >/dev/null; then
@@ -317,7 +317,7 @@ main() {
     if upload_latest; then
         exit 0
     else
-        osascript -e "display notification \"FAISS Memory Google Drive backup failed! Check gdrive.log\" with title \"FAISS Memory Backup Alert\"" 2>/dev/null || true
+        osascript -e "display notification \"Memories Google Drive backup failed! Check gdrive.log\" with title \"Memories Backup Alert\"" 2>/dev/null || true
         exit 1
     fi
 }

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# FAISS Memory - Periodic Backup
+# Memories - Periodic Backup
 # Triggers a backup via the API and saves a local snapshot
 #
 # Usage:
@@ -9,10 +9,10 @@
 #   ./scripts/backup.sh --cleanup    # Only run cleanup
 #
 # Environment:
-#   FAISS_API_KEY     - API key for the FAISS service (required if auth enabled)
-#   FAISS_URL         - Service URL (default: http://localhost:8900)
-#   FAISS_DATA_DIR    - Path to Docker volume data dir (default: ./data relative to repo root)
-#   BACKUP_DIR        - Where to store snapshots (default: ~/backups/faiss-memory)
+#   MEMORIES_API_KEY     - API key for the Memories service (required if auth enabled)
+#   MEMORIES_URL         - Service URL (default: http://localhost:8900)
+#   MEMORIES_DATA_DIR    - Path to Docker volume data dir (default: ./data relative to repo root)
+#   BACKUP_DIR        - Where to store snapshots (default: ~/backups/memories)
 #   RETENTION_DAYS    - Days to keep local snapshots (default: 30)
 #
 
@@ -29,11 +29,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Configuration (all overridable via env vars)
-BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/faiss-memory}"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backups/memories}"
 LOG_FILE="$BACKUP_DIR/backup.log"
-FAISS_URL="${FAISS_URL:-http://localhost:8900}"
-API_KEY="${FAISS_API_KEY}"
-FAISS_DATA_DIR="${FAISS_DATA_DIR:-$PROJECT_DIR/data}"
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+API_KEY="${MEMORIES_API_KEY}"
+MEMORIES_DATA_DIR="${MEMORIES_DATA_DIR:-$PROJECT_DIR/data}"
 RETENTION_DAYS="${RETENTION_DAYS:-30}"
 
 # Parse arguments
@@ -70,7 +70,7 @@ create_local_snapshot() {
 
     # Trigger backup via API
     local response=$(curl -s -w "\n%{http_code}" \
-        -X POST "$FAISS_URL/backup?prefix=scheduled" \
+        -X POST "$MEMORIES_URL/backup?prefix=scheduled" \
         -H "X-API-Key: $API_KEY" 2>/dev/null)
 
     local http_code=$(echo "$response" | tail -1)
@@ -82,15 +82,15 @@ create_local_snapshot() {
     fi
 
     # Copy the data files to our local snapshot
-    if [ ! -d "$FAISS_DATA_DIR" ]; then
-        log "ERROR" "Data directory not found: $FAISS_DATA_DIR"
+    if [ ! -d "$MEMORIES_DATA_DIR" ]; then
+        log "ERROR" "Data directory not found: $MEMORIES_DATA_DIR"
         return 1
     fi
 
     mkdir -p "$snapshot_dir"
-    cp -f "$FAISS_DATA_DIR/index.faiss" "$snapshot_dir/" 2>/dev/null || true
-    cp -f "$FAISS_DATA_DIR/metadata.json" "$snapshot_dir/" 2>/dev/null || true
-    cp -f "$FAISS_DATA_DIR/config.json" "$snapshot_dir/" 2>/dev/null || true
+    cp -f "$MEMORIES_DATA_DIR/index.faiss" "$snapshot_dir/" 2>/dev/null || true
+    cp -f "$MEMORIES_DATA_DIR/metadata.json" "$snapshot_dir/" 2>/dev/null || true
+    cp -f "$MEMORIES_DATA_DIR/config.json" "$snapshot_dir/" 2>/dev/null || true
 
     local size=$(du -sh "$snapshot_dir" 2>/dev/null | cut -f1)
     log "SUCCESS" "Snapshot created: $timestamp ($size)"
@@ -137,7 +137,7 @@ record_failure() {
     # Alert after 3 consecutive failures
     if [ "$count" -ge 3 ]; then
         log "ERROR" "ALERT: $count consecutive backup failures!"
-        osascript -e "display notification \"$count consecutive FAISS backup failures! Check backup.log\" with title \"FAISS Memory Backup Alert\"" 2>/dev/null || true
+        osascript -e "display notification \"$count consecutive Memories backup failures! Check backup.log\" with title \"Memories Backup Alert\"" 2>/dev/null || true
     fi
 }
 

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Install/uninstall cron jobs for FAISS Memory backups
+# Install/uninstall cron jobs for Memories backups
 #
 # Jobs:
 #   - Local snapshot every 30 minutes
@@ -12,8 +12,8 @@
 #   ./scripts/install-cron.sh status    # Check if installed
 #
 # Prerequisites:
-#   - Docker running with faiss-memory container
-#   - FAISS_API_KEY set in shell profile (if auth enabled)
+#   - Docker running with memories container
+#   - MEMORIES_API_KEY set in shell profile (if auth enabled)
 #
 # Optional (for Google Drive off-site backups):
 #   - Install gog CLI: https://github.com/skratchdot/gog
@@ -23,10 +23,10 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKUP_SCRIPT="$SCRIPT_DIR/backup.sh"
-LOG_DIR="${BACKUP_DIR:-$HOME/backups/faiss-memory}"
+LOG_DIR="${BACKUP_DIR:-$HOME/backups/memories}"
 
 # Cron identifier
-CRON_COMMENT="# FAISS Memory backup"
+CRON_COMMENT="# Memories backup"
 
 # Run every 30 minutes
 BACKUP_SCHEDULE="*/30 * * * *"
@@ -45,11 +45,11 @@ case "$1" in
         CURRENT=$(crontab -l 2>/dev/null || true)
 
         # Add backup job if not present
-        if ! echo "$CURRENT" | grep -q "FAISS Memory backup"; then
+        if ! echo "$CURRENT" | grep -q "Memories backup"; then
             UPDATED="$CURRENT
 $BACKUP_LINE"
             echo "$UPDATED" | crontab -
-            echo "Installed FAISS Memory backup cron job"
+            echo "Installed Memories backup cron job"
         else
             echo "Cron job already installed"
         fi
@@ -71,18 +71,18 @@ $BACKUP_LINE"
         ;;
 
     uninstall)
-        crontab -l 2>/dev/null | grep -v "FAISS Memory backup" | crontab -
+        crontab -l 2>/dev/null | grep -v "Memories backup" | crontab -
         echo "Cron job removed"
         ;;
 
     status)
-        echo "FAISS Memory Backup Status"
+        echo "Memories Backup Status"
         echo "=========================="
         echo ""
 
-        if crontab -l 2>/dev/null | grep -q "FAISS Memory backup"; then
+        if crontab -l 2>/dev/null | grep -q "Memories backup"; then
             echo "Cron: INSTALLED"
-            crontab -l | grep "FAISS Memory backup" | sed 's/^/  /'
+            crontab -l | grep "Memories backup" | sed 's/^/  /'
         else
             echo "Cron: NOT INSTALLED"
         fi

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -70,7 +70,7 @@ class TestCloudSyncInit(unittest.TestCase):
         }
         with patch.dict(os.environ, env, clear=True):
             sync = CloudSync.from_env()
-            self.assertEqual(sync.prefix, "faiss-memory/")
+            self.assertEqual(sync.prefix, "memories/")
 
 
 class TestCloudSyncOperations(unittest.TestCase):

--- a/tests/test_container_config.py
+++ b/tests/test_container_config.py
@@ -59,15 +59,15 @@ def test_compose_healthchecks_use_python_probe() -> None:
 def test_compose_defaults_to_core_target() -> None:
     for compose_file in ("docker-compose.yml", "docker-compose.snippet.yml"):
         contents = _read(compose_file)
-        assert "target: ${FAISS_IMAGE_TARGET:-core}" in contents
-        assert "image: faiss-memory:${FAISS_IMAGE_TARGET:-core}" in contents
+        assert "target: ${MEMORIES_IMAGE_TARGET:-core}" in contents
+        assert "image: memories:${MEMORIES_IMAGE_TARGET:-core}" in contents
         assert "PRELOAD_MODEL: ${PRELOAD_MODEL:-false}" in contents
 
 
 def test_compose_sets_memory_and_allocator_guardrails() -> None:
     for compose_file in ("docker-compose.yml", "docker-compose.snippet.yml"):
         contents = _read(compose_file)
-        assert "mem_limit: ${FAISS_MEM_LIMIT:-3g}" in contents
+        assert "mem_limit: ${MEMORIES_MEM_LIMIT:-3g}" in contents
         assert "MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-2}" in contents
         assert "MALLOC_TRIM_THRESHOLD_=${MALLOC_TRIM_THRESHOLD_:-131072}" in contents
         assert "MALLOC_MMAP_THRESHOLD_=${MALLOC_MMAP_THRESHOLD_:-131072}" in contents

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -23,7 +23,7 @@ def populated_engine(engine):
             "JavaScript runs in the browser and on Node.js",
             "Docker containers package applications with their dependencies",
             "FastAPI is a modern Python web framework",
-            "FAISS is a library for efficient similarity search",
+            "Memories uses a library for efficient similarity search",
         ],
         sources=["lang.md", "lang.md", "devops.md", "python.md", "ml.md"],
     )
@@ -70,8 +70,8 @@ class TestHybridSearch:
 
     def test_bm25_exact_match_boost(self, populated_engine):
         """BM25 should boost exact keyword matches"""
-        results = populated_engine.hybrid_search("FAISS", k=3)
-        assert any("FAISS" in r["text"] for r in results)
+        results = populated_engine.hybrid_search("Memories", k=3)
+        assert any("Memories" in r["text"] for r in results)
 
 
 class TestDelete:

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -29,6 +29,7 @@ def test_metrics_includes_latency_error_queue_and_memory_sections(client):
     # Successful request
     health_response = test_client.get("/health")
     assert health_response.status_code == 200
+    assert health_response.json()["service"] == "memories"
 
     # Error request (validation failure)
     bad_search = test_client.post(

--- a/webui/index.html
+++ b/webui/index.html
@@ -10,7 +10,7 @@
   <div class="backdrop"></div>
   <main class="shell">
     <header class="hero">
-      <p class="eyebrow">FAISS MEMORY</p>
+      <p class="eyebrow">Memories MEMORY</p>
       <h1>Memory Observatory</h1>
       <p class="subtitle">Browse, filter, and inspect stored memories without leaving the browser.</p>
     </header>


### PR DESCRIPTION
## Summary
- hard-cut over external naming from legacy labels to **Memories**
- standardized env surfaces to `MEMORIES_*` in MCP, integrations, and scripts
- renamed compose service/image/container references to `memories`
- switched cloud backup defaults to `memories/` and `memories-backups`
- updated docs/UI labels/integration commands to Memories naming

## Implementation Notes
- kept API route contracts unchanged; only identity naming changed
- no compatibility aliases were added (intentional hard cutover)

## Verification
- `/Users/dk/projects/memories/.venv/bin/python -m pytest -q`
- result: `114 passed, 3 warnings`

## Scope
- runtime/API: `app.py`, `memory_engine.py`, `runtime_memory.py`, `cloud_sync.py`, `onnx_embedder.py`
- MCP: `mcp-server/index.js`, `mcp-server/package.json`, `mcp-server/package-lock.json`
- deployment/scripts/docs/integrations: updated throughout repo
- tests updated for naming assertions (`test_container_config`, `test_metrics_api`, `test_cloud_sync`, `test_memory_engine`)

No merge performed.
