### PR TITLE
fix: startup/runtime hotfixes after cutover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ ENV MODEL_CACHE_DIR=/data/model-cache \
 # Copy application code
 COPY onnx_embedder.py .
 COPY memory_engine.py .
+COPY entity_locks.py .
+COPY qdrant_config.py .
+COPY qdrant_store.py .
 COPY cloud_sync.py .
 COPY runtime_memory.py .
 COPY llm_provider.py .

--- a/app.py
+++ b/app.py
@@ -388,7 +388,7 @@ async def lifespan(app: FastAPI):
     memory = MemoryEngine(data_dir=DATA_DIR)
     logger.info(
         "Loaded %d memories (%s model, %d dims)",
-        memory.index.ntotal,
+        len(memory.metadata),
         memory.config.get("model"),
         memory.dim,
     )


### PR DESCRIPTION
## Summary
- include new runtime modules in Docker image (, , ) to prevent startup import failure
- update lifespan startup logging to use backend-agnostic memory count () instead of removed FAISS field

## Verification
- /Users/dk/projects/memories/.venv/bin/python -m pytest -q
- result: 145 passed