### PR TITLE
feat: OpenClaw QMD bridge for unified memory_search

### DIFF
--- a/integrations/openclaw-skill.md
+++ b/integrations/openclaw-skill.md
@@ -1,7 +1,7 @@
 ---
 name: memories
-version: 2.0.0
-description: Memories-based semantic memory search via Docker service. Fast (<20ms), local, with hybrid BM25+vector search, auto-dedup, and automatic backups.
+version: 2.1.0
+description: Memories-based semantic memory search via Docker service. Fast (<20ms), local, with hybrid BM25+vector search, auto-dedup, and automatic backups. Includes OpenClaw QMD bridge for unified memory_search integration.
 metadata:
   clawdbot:
     emoji: "🧠"
@@ -24,12 +24,263 @@ Local semantic memory using Memories vector search + BM25 hybrid retrieval (Dock
 - **Backed up**: Automatic backups before operations
 - **Independent**: Survives OpenClaw upgrades
 - **CRUD**: Full create, read, update, delete support
+- **QMD Bridge**: Sync Memories into OpenClaw's native `memory_search` via QMD
 
 ## Prerequisites
 
 - Docker service running: `docker ps | grep memories`
 - If not running: `cd /path/to/memories && docker compose up -d memories`
 - `MEMORIES_API_KEY` env var must be set (loaded from shell profile)
+
+---
+
+## OpenClaw QMD Bridge Integration
+
+### The Problem
+
+OpenClaw's built-in `memory_search` tool only queries its native backends (built-in SQLite or QMD). Memories runs as a separate Docker service with its own vector index. Without a bridge, Memories content is invisible to `memory_search` — the agent must explicitly call Memories API functions to access it.
+
+### The Solution
+
+A sync script exports all Memories content as grouped markdown files into a directory that QMD indexes as a collection. This makes Memories content discoverable through OpenClaw's native `memory_search` alongside workspace files and session transcripts.
+
+For writes, the agent dual-writes: storing insights in both workspace markdown files (for QMD) and the Memories API (for the vector index). This keeps both systems in sync.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  OpenClaw memory_search (unified query)             │
+│  ├── memory files (MEMORY.md + memory/*.md)         │  ← QMD collection: memory
+│  ├── session transcripts                            │  ← QMD collection: sessions-<agentId>
+│  └── Memories content (synced)                      │  ← QMD collection: memories-<agentId>
+│           ↑                                         │
+│     sync script (daily)                             │
+│           ↑                                         │
+│     Memories API (localhost:8900)                    │
+└─────────────────────────────────────────────────────┘
+
+Writes:
+  Agent ──→ memory/YYYY-MM-DD.md  (QMD indexes directly)
+       └──→ POST /memory/add      (Memories API, synced to QMD via script)
+```
+
+### Setup: QMD Bridge Sync Script
+
+Create this script in your workspace (e.g. `scripts/sync-memories-to-qmd.sh`):
+
+```bash
+#!/bin/bash
+# Sync Memories → QMD collection for unified memory_search
+# Run daily via heartbeat or cron to keep QMD in sync with Memories.
+set -euo pipefail
+
+MEMORIES_API="${MEMORIES_API:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+AGENT_ID="${OPENCLAW_AGENT_ID:-jack}"
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+EXPORT_DIR="$STATE_DIR/agents/$AGENT_ID/qmd/memories-export"
+COLLECTION="memories-$AGENT_ID"
+
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+# Auth header (optional — only needed if MEMORIES_API_KEY is set)
+AUTH_HEADER=""
+if [[ -n "$MEMORIES_API_KEY" ]]; then
+  AUTH_HEADER="-H \"X-API-Key: $MEMORIES_API_KEY\""
+fi
+
+# Check API is up
+if ! curl -sf "$MEMORIES_API/health" >/dev/null 2>&1; then
+  echo "❌ Memories API not responding at $MEMORIES_API"
+  exit 1
+fi
+
+mkdir -p "$EXPORT_DIR"
+
+TOTAL=$(curl -sf "$MEMORIES_API/health" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total_memories',0))")
+echo "📦 Exporting $TOTAL memories from Memories..."
+
+# Export all memories and write as grouped markdown files
+python3 - "$MEMORIES_API" "$EXPORT_DIR" "$MEMORIES_API_KEY" << 'PYEOF'
+import json, os, re, sys, urllib.request
+
+api = sys.argv[1]
+export_dir = sys.argv[2]
+api_key = sys.argv[3] if len(sys.argv) > 3 else ""
+
+# Clean old exports
+for f in os.listdir(export_dir):
+    if f.endswith('.md'):
+        os.remove(os.path.join(export_dir, f))
+
+# Fetch all memories (paginated)
+memories = []
+offset = 0
+while True:
+    url = f"{api}/memories?offset={offset}&limit=100"
+    req = urllib.request.Request(url)
+    if api_key:
+        req.add_header("X-API-Key", api_key)
+    resp = urllib.request.urlopen(req)
+    data = json.loads(resp.read())
+    batch = data.get("memories", [])
+    memories.extend(batch)
+    if len(batch) < 100:
+        break
+    offset += 100
+
+# Group by top-level source folder
+folders = {}
+for m in memories:
+    source = m.get('source', 'uncategorized') or 'uncategorized'
+    folder = source.split('/')[0] if '/' in source else source
+    folder = re.sub(r'[^\w\-]', '_', folder)
+    folders.setdefault(folder, []).append(m)
+
+# Write one markdown file per folder
+count = 0
+for folder, mems in folders.items():
+    filepath = os.path.join(export_dir, f"{folder}.md")
+    with open(filepath, 'w') as f:
+        f.write(f"# Memories: {folder}\n\n")
+        f.write(f"> Auto-synced from Memories project\n")
+        f.write(f"> {len(mems)} entries\n\n")
+        for m in mems:
+            text = m.get('text', '').strip()
+            source = m.get('source', '')
+            ts = (m.get('timestamp') or '')[:10]
+            f.write(f"## [{source}] ({ts})\n\n{text}\n\n---\n\n")
+            count += 1
+
+print(f"✅ Exported {count} memories to {len(folders)} files")
+PYEOF
+
+# Create or update QMD collection
+if qmd collection list 2>/dev/null | grep -q "$COLLECTION"; then
+  echo "🔄 Updating QMD collection '$COLLECTION'..."
+  qmd update -c "$COLLECTION" 2>&1 | tail -3
+else
+  echo "📁 Creating QMD collection '$COLLECTION'..."
+  qmd collection add --name "$COLLECTION" "$EXPORT_DIR" '**/*.md' 2>&1
+  qmd update -c "$COLLECTION" 2>&1 | tail -3
+fi
+
+# Embed new chunks (required for vector search)
+echo "🧠 Embedding new chunks..."
+qmd embed 2>&1 | tail -3
+
+echo "✅ Sync complete — Memories are now searchable via memory_search"
+```
+
+**Make it executable:**
+```bash
+chmod +x scripts/sync-memories-to-qmd.sh
+```
+
+**Run the initial sync:**
+```bash
+bash scripts/sync-memories-to-qmd.sh
+```
+
+### Setup: QMD Session Collection Fix
+
+OpenClaw expects session transcript collections named `sessions-<agentId>` (e.g. `sessions-jack`). If QMD created the collection with a different name, `memory_search` will fail to find session transcripts and fall back to the built-in search (which doesn't cover sessions).
+
+**Check if sessions are indexed:**
+```bash
+openclaw memory status
+# Look for: sessions · 0/N files · 0 chunks
+# If 0 chunks but N files exist, the collection name is wrong.
+```
+
+**Fix the naming:**
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"  # Change to your agent ID
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+# Remove old collection and recreate with correct name
+qmd collection remove sessions 2>/dev/null
+qmd collection remove "sessions-$AGENT_ID" 2>/dev/null
+qmd collection add --name "sessions-$AGENT_ID" \
+  "$STATE_DIR/agents/$AGENT_ID/qmd/sessions" '**/*.md'
+```
+
+### Setup: SQLite WAL Lock Recovery
+
+If QMD searches fail with `SQLITE_BUSY_RECOVERY`, a stale WAL lock file is blocking access. This can happen after a crash or ungraceful shutdown.
+
+**Fix:**
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+sqlite3 "$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache/qmd/index.sqlite" \
+  "PRAGMA wal_checkpoint(TRUNCATE);"
+```
+
+### Scheduling the Sync
+
+**Option A: OpenClaw Heartbeat (recommended)**
+
+Add to your `HEARTBEAT.md`:
+```markdown
+### Memories → QMD Sync (daily)
+- Run `bash ~/your-workspace/scripts/sync-memories-to-qmd.sh`
+- Keeps `memory_search` results unified across all memory sources
+```
+
+**Option B: OpenClaw Cron Job**
+
+```bash
+# Via OpenClaw cron — runs daily at 6 AM
+openclaw cron add --name "Memories QMD Sync" \
+  --schedule '{"kind":"cron","expr":"0 6 * * *"}' \
+  --payload '{"kind":"systemEvent","text":"Run: bash ~/your-workspace/scripts/sync-memories-to-qmd.sh"}' \
+  --session-target main
+```
+
+**Option C: System Crontab**
+
+```bash
+crontab -e
+# Add:
+0 6 * * * /path/to/workspace/scripts/sync-memories-to-qmd.sh >> /tmp/memories-sync.log 2>&1
+```
+
+### Dual-Write Pattern (Recommended)
+
+To keep Memories and QMD in sync without waiting for the daily sync, the agent should dual-write: store significant insights in both systems simultaneously.
+
+**When the agent learns something worth remembering:**
+
+1. **Write to daily markdown file** (QMD picks this up automatically):
+   ```
+   Append to memory/YYYY-MM-DD.md
+   ```
+
+2. **Write to Memories API** (immediate vector search availability):
+   ```bash
+   memory_add_memories "The insight or learning" "source/topic"
+   ```
+
+3. **The daily sync script** acts as a safety net — if either write was missed, the sync reconciles by exporting all Memories content to QMD.
+
+**When to dual-write:**
+- Decisions with rationale
+- User preferences (explicit or observed)
+- Bug root causes and fixes
+- Architectural patterns
+- Lessons learned from failures
+
+**When NOT to dual-write (markdown only is fine):**
+- Routine task completions
+- Temporary context
+- Raw session logs
+
+---
 
 ## Commands
 
@@ -430,6 +681,7 @@ During heartbeats, I can:
 2. **Manual alternative**: Check novelty with `memory_is_novel`, then add if novel with `memory_add_memories` (auto-dedup enabled)
 3. **Recall context** at task start with `memory_recall_memories`
 4. **Auto-backup** handled by service
+5. **Sync to QMD** via `sync-memories-to-qmd.sh` (daily, keeps `memory_search` unified)
 
 ## Troubleshooting
 
@@ -452,6 +704,44 @@ memory_backups
 memory_restore "BACKUP_NAME"
 ```
 
+### QMD bridge not finding Memories content
+```bash
+# Re-run the sync
+bash scripts/sync-memories-to-qmd.sh
+
+# Verify the collection exists
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+qmd collection list | grep memories
+
+# Check OpenClaw sees it
+openclaw memory status
+```
+
+### QMD SQLite lock errors (SQLITE_BUSY_RECOVERY)
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+sqlite3 "$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache/qmd/index.sqlite" \
+  "PRAGMA wal_checkpoint(TRUNCATE);"
+```
+
+### Session transcripts not searchable (0 chunks)
+```bash
+# Fix collection naming — OpenClaw expects sessions-<agentId>
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+qmd collection remove sessions 2>/dev/null
+qmd collection remove "sessions-$AGENT_ID" 2>/dev/null
+qmd collection add --name "sessions-$AGENT_ID" \
+  "$STATE_DIR/agents/$AGENT_ID/qmd/sessions" '**/*.md'
+```
+
 ## Notes
 
 - Service runs independently of OpenClaw
@@ -460,3 +750,4 @@ memory_restore "BACKUP_NAME"
 - Read-only access to workspace files
 - All data persists in the bind-mounted `./data/` directory (configured in `docker-compose.yml`)
 - API docs available at http://localhost:8900/docs
+- QMD bridge sync is one-way (Memories → QMD); writes to QMD markdown don't flow back to Memories


### PR DESCRIPTION
## What

Adds OpenClaw QMD bridge integration to `integrations/openclaw-skill.md` so that Memories content is discoverable through OpenClaw's native `memory_search` tool.

## Why

OpenClaw's `memory_search` only queries its native backends (built-in SQLite or QMD). Without a bridge, Memories content is invisible to `memory_search` — agents must explicitly call the Memories API. This creates a split-brain problem where some knowledge lives in workspace markdown files and some in Memories, but searches only cover one system.

## What's Added

### QMD Bridge Sync (`sync-memories-to-qmd.sh`)
- Exports all Memories content as grouped markdown files
- QMD indexes them as a `memories-<agentId>` collection
- Supports pagination, source-based grouping, and auth
- Configurable via env vars (`MEMORIES_API`, `MEMORIES_API_KEY`, `OPENCLAW_AGENT_ID`)

### Dual-Write Pattern
- Documents when and how agents should write to both systems simultaneously
- Markdown files for QMD (auto-indexed) + Memories API for vector search
- Daily sync script acts as safety net for missed writes

### Troubleshooting
- QMD session collection naming mismatch (`sessions` vs `sessions-<agentId>`)
- SQLite WAL lock recovery (`SQLITE_BUSY_RECOVERY`)
- Scheduling options (heartbeat, cron, system crontab)

### Architecture Diagram
Shows the unified query flow: `memory_search` → QMD → (memory files + sessions + synced Memories content)

## Changes
- `integrations/openclaw-skill.md`: Updated from v2.0.0 → v2.1.0 with new QMD bridge section

## Testing
Tested on a live OpenClaw instance:
- 171 memories exported to 22 markdown files
- QMD indexed all files successfully (179 chunks embedded)
- `memory_search` returns results from Memories, sessions, and workspace files in a single query
- Session collection naming fix verified (92 sessions indexed)
- SQLite WAL checkpoint fix verified