### PR TITLE
Harden scoped auth + Codex hook parity; update tests/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Scoped extraction hardening:
+  - `/memory/extract` now requires explicit `source` for scoped non-admin keys
+  - extraction AUDN flow now scopes similar-memory context and update/delete execution to allowed prefixes
+  - `/memory/extract/{job_id}` now enforces job visibility by admin/owner/source scope
+- Scoped read/write hardening:
+  - `/memory/delete-by-source` now enforces per-memory source authorization for scoped keys
+  - `/memories` now returns scope-correct `total` for scoped keys
+  - `/memories/count` now counts only accessible memories and rejects disallowed source filters
+- Admin-only endpoint hardening:
+  - `/usage` now requires admin privileges
+  - `/backups` now requires admin privileges
+- Codex notify parity hardening:
+  - `memory-codex-notify.sh` now supports transcript fallback, broader payload variants, and scoped-source overrides via `MEMORIES_SOURCE_PREFIX` / `MEMORIES_SOURCE`
+
+### Docs
+- Clarified Codex setup prerequisites (`npm install` in `mcp-server`, `jq`/`curl`, running service)
+- Added explicit guidance for merging Codex `notify` config when an existing `notify` entry is already present
+- Added scoped-key guidance for Codex notify source overrides and client-aware source-prefix conventions in skill/setup docs
+
 ## [2.0.0] - 2026-03-05
 
 ### Added

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -50,6 +50,18 @@ docker compose up -d --build memories
 
 ## 4) Install integrations (recommended)
 
+Prerequisites for installer mode:
+- `jq` and `curl` installed
+- running Memories service (`/health` responds)
+
+If you plan to install Codex integration, install MCP server deps first:
+
+```bash
+cd mcp-server
+npm install
+cd ..
+```
+
 ```bash
 ./integrations/claude-code/install.sh --auto
 ```
@@ -60,6 +72,11 @@ This auto-detects and configures:
 - OpenClaw skill (`~/.openclaw/skills/memories/SKILL.md`)
 
 Cursor is supported via MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json`) and is currently manual.
+
+Note for Codex: if `~/.codex/config.toml` already contains a `notify` entry, merge
+`~/.codex/hooks/memory/memory-codex-notify.sh` into that list manually.
+For scoped API keys, set `MEMORIES_SOURCE_PREFIX` (or `MEMORIES_SOURCE`) in
+`~/.config/memories/env` so notify writes stay inside authorized prefixes.
 
 The installer writes:
 - hook runtime vars to `~/.config/memories/env` (`MEMORIES_URL`, optional `MEMORIES_API_KEY`)
@@ -113,7 +130,7 @@ ln -s /path/to/memories/skills/memories ~/.claude/skills/memories
 - **Read**: Proactively searches memories before asking clarifying questions or entering a domain with prior context
 - **Write**: Hybrid approach — uses `memory_add` for simple facts, `memory_extract` for lifecycle operations (decision changes, deferred work completion, contradictions)
 - **Maintain**: Handles updates and deletes via AUDN, plus explicit cleanup with `memory_delete` / `memory_delete_by_source`
-- Enforces consistent source prefixes (`claude-code/{project}`, `learning/{project}`, `wip/{project}`)
+- Enforces consistent source prefixes (`claude-code/{project}` or `codex/{project}`, plus `learning/{project}` and `wip/{project}`)
 
 The skill does NOT replace hooks (passive baseline) or CC's built-in auto-memory. It complements them with active judgment about what's worth remembering and when to update or remove stale memories.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ mkdir -p ~/.claude/skills/memories
 ln -s /path/to/memories/skills/memories ~/.claude/skills/memories
 ```
 
-The skill teaches Claude three responsibilities: *when* to search (proactive recall), *when* and *how* to store (hybrid `memory_add` + `memory_extract`), and *when* to maintain (updates, deletes, cleanup via AUDN). It adds ~11% token overhead but improves memory discipline by ~43% in eval benchmarks.
+The skill teaches the assistant three responsibilities: *when* to search (proactive recall), *when* and *how* to store (hybrid `memory_add` + `memory_extract`), and *when* to maintain (updates, deletes, cleanup via AUDN). It adds ~11% token overhead but improves memory discipline by ~43% in eval benchmarks.
 
 **Usage** (Claude Code will call these automatically when relevant):
 
@@ -308,11 +308,22 @@ MEMORIES_URL = "http://localhost:8900"
 MEMORIES_API_KEY = "your-api-key-here"
 ```
 
+If your API key is prefix-scoped and does not allow `codex/*`, set hook source overrides in `~/.config/memories/env`:
+
+```bash
+MEMORIES_SOURCE_PREFIX="your-authorized-prefix"
+# or exact source:
+# MEMORIES_SOURCE="your-authorized-prefix/your-project"
+```
+
 3. Restart Codex. The `memory_search`, `memory_add`, `memory_extract`, `memory_delete`, `memory_delete_by_source`, `memory_count`, `memory_list`, `memory_stats`, `memory_is_novel`, and other tools will be available.
 
 **Automatic memory layer for Codex:**
 
 ```bash
+cd memories/mcp-server
+npm install
+cd ..
 ./integrations/claude-code/install.sh --codex
 ```
 
@@ -320,6 +331,12 @@ This configures:
 - MCP server registration in `~/.codex/config.toml`
 - `notify` hook script at `~/.codex/hooks/memory/memory-codex-notify.sh` for after-turn extraction
 - default `developer_instructions` (if not already set) to bias `memory_search` usage on each turn
+- hook env loading from `~/.config/memories/env` (or `MEMORIES_ENV_FILE`) for `MEMORIES_URL`, `MEMORIES_API_KEY`, and optional source overrides (`MEMORIES_SOURCE_PREFIX`, `MEMORIES_SOURCE`)
+
+The installer requires `jq`, `curl`, and a running Memories service (`/health` must respond).
+If `~/.codex/config.toml` already has a `notify = [...]` entry, the installer will not overwrite it —
+merge the Memories notify script into that array manually.
+For scoped API keys, set `MEMORIES_SOURCE_PREFIX` (or `MEMORIES_SOURCE`) so hook writes stay inside authorized prefixes.
 
 Codex currently exposes an after-turn `notify` hook, not Claude's 5-event hook surface.
 
@@ -852,12 +869,22 @@ Memories supports automatic retrieval/extraction, with client-specific behavior:
 
 | Event | Mechanism | What happens |
 |-------|-----------|--------------|
-| After each completed turn | `notify` -> `memory-codex-notify.sh` | Sends user+assistant exchange to `/memory/extract` asynchronously |
+| After each completed turn | `notify` -> `memory-codex-notify.sh` | Sends user+assistant exchange to `/memory/extract` asynchronously (loads hook env file, handles snake/camel/kebab payload variants, supports transcript fallback and source overrides) |
 | On new turns | MCP tools + developer instructions | Encourages focused `memory_search` before implementation-heavy responses |
 
 Codex does not currently expose the Claude-style SessionStart/UserPromptSubmit/PreCompact/SessionEnd hook callbacks in `config.toml`.
 
 ### Quick setup
+
+**Prerequisites:**
+- `jq` and `curl` installed (required by installer)
+- running Memories service (`curl -s http://localhost:8900/health | jq .`)
+- if installing Codex integration, MCP deps installed:
+
+```bash
+cd memories/mcp-server
+npm install
+```
 
 **One-command auto-detect installer (recommended):**
 ```bash
@@ -872,7 +899,7 @@ This detects and configures any available targets on your machine:
 Cursor is supported via manual MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json`).
 
 The installer writes runtime config to:
-- `~/.config/memories/env` for hook vars (`MEMORIES_URL`, optional `MEMORIES_API_KEY`)
+- `~/.config/memories/env` for hook vars (`MEMORIES_URL`, optional `MEMORIES_API_KEY`, optional `MEMORIES_SOURCE_PREFIX` / `MEMORIES_SOURCE` for Codex notify source control)
 - repo `.env` for extraction vars (`EXTRACT_PROVIDER`, provider keys/URL)
 
 **Target only Claude, Cursor, or Codex:**

--- a/app.py
+++ b/app.py
@@ -290,6 +290,41 @@ def _require_admin(auth: AuthContext) -> None:
         raise HTTPException(status_code=403, detail="Admin key required")
 
 
+def _count_accessible_memories(auth: AuthContext, source_prefix: Optional[str] = None) -> Optional[int]:
+    """Count memories visible to this auth context using in-memory metadata when available."""
+    if auth.prefixes is None:
+        return None
+    metadata = getattr(memory, "metadata", None)
+    if not isinstance(metadata, list):
+        return None
+
+    total = 0
+    for record in metadata:
+        if not isinstance(record, dict):
+            continue
+        source = str(record.get("source", ""))
+        if source_prefix and not source.startswith(source_prefix):
+            continue
+        if auth.can_read(source):
+            total += 1
+    return total
+
+
+def _can_access_extract_job(auth: AuthContext, job: Dict[str, Any]) -> bool:
+    """Authorize visibility of extraction jobs."""
+    if auth.can_manage_keys:
+        return True
+
+    source = str(job.get("source", ""))
+    if source and auth.can_read(source):
+        return True
+
+    if auth.key_id and job.get("auth_key_id") == auth.key_id:
+        return True
+
+    return False
+
+
 # -- App lifecycle ------------------------------------------------------------
 
 memory: MemoryEngine = None  # type: ignore
@@ -513,12 +548,44 @@ def _fallback_extract_facts(messages: str) -> List[str]:
     return candidates
 
 
-def _run_fallback_extraction(messages: str, source: str, context: str) -> Dict[str, Any]:
+def _run_fallback_extraction(
+    messages: str,
+    source: str,
+    context: str,
+    allowed_prefixes: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     """Fallback add-only extraction path for disabled or runtime-failed providers."""
     facts = _fallback_extract_facts(messages)
     actions: List[Dict[str, Any]] = []
     stored_count = 0
+
+    # Scoped keys must provide an explicit source.
+    if allowed_prefixes is not None and not source:
+        return {
+            "actions": [],
+            "extracted_count": len(facts),
+            "stored_count": 0,
+            "updated_count": 0,
+            "deleted_count": 0,
+            "mode": "fallback_add",
+            "error": "source_required",
+        }
+
     source_value = source or "extract/fallback"
+    if allowed_prefixes is not None and not AuthContext(
+        role="read-write",
+        prefixes=allowed_prefixes,
+        key_type="managed",
+    ).can_write(source_value):
+        return {
+            "actions": [],
+            "extracted_count": len(facts),
+            "stored_count": 0,
+            "updated_count": 0,
+            "deleted_count": 0,
+            "mode": "fallback_add",
+            "error": "source_not_authorized",
+        }
 
     for fact in facts:
         is_new, similar = memory.is_novel(fact, threshold=EXTRACT_FALLBACK_NOVELTY_THRESHOLD)
@@ -621,6 +688,7 @@ async def _extract_worker(worker_id: int) -> None:
                 request_data["messages"],
                 request_data["source"],
                 request_data["context"],
+                request_data.get("allowed_prefixes"),
             )
             if EXTRACT_FALLBACK_ADD_ENABLED and _should_use_runtime_fallback(result):
                 fallback_result = await run_in_threadpool(
@@ -628,6 +696,7 @@ async def _extract_worker(worker_id: int) -> None:
                     request_data["messages"],
                     request_data["source"],
                     request_data["context"],
+                    request_data.get("allowed_prefixes"),
                 )
                 result = _merge_runtime_fallback_result(result, fallback_result)
                 logger.info(
@@ -1174,8 +1243,13 @@ async def metrics(request: Request):
 
 
 @app.get("/usage")
-async def usage(period: str = Query("7d", regex="^(today|7d|30d|all)$")):
+async def usage(
+    request: Request,
+    period: str = Query("7d", pattern="^(today|7d|30d|all)$"),
+):
     """Persistent usage analytics (opt-in via USAGE_TRACKING=true)."""
+    auth = _get_auth(request)
+    _require_admin(auth)
     return usage_tracker.get_usage(period)
 
 
@@ -1455,8 +1529,34 @@ async def delete_by_source(request_body: DeleteBySourceRequest, request: Request
     _require_write(auth, request_body.source_pattern)
     logger.info("Delete by source: pattern=%s", request_body.source_pattern)
     try:
-        result = memory.delete_by_source(request_body.source_pattern)
-        return {"success": True, **result}
+        # Backward-compatible behavior for admin/unrestricted callers.
+        if auth.prefixes is None:
+            result = memory.delete_by_source(request_body.source_pattern)
+            return {"success": True, **result}
+
+        # Scoped keys: resolve matching IDs and enforce source-level checks before deletion.
+        matching_ids: List[int] = []
+        metadata = getattr(memory, "metadata", [])
+        if isinstance(metadata, list):
+            for record in metadata:
+                if not isinstance(record, dict):
+                    continue
+                source = str(record.get("source", ""))
+                if request_body.source_pattern in source and auth.can_write(source):
+                    rid = record.get("id")
+                    if isinstance(rid, int):
+                        matching_ids.append(rid)
+
+        if not matching_ids:
+            return {"success": True, "deleted_count": 0}
+
+        result = memory.delete_memories(matching_ids)
+        return {
+            "success": True,
+            "deleted_count": result.get("deleted_count", 0),
+            "deleted_ids": result.get("deleted_ids", []),
+            "missing_ids": result.get("missing_ids", []),
+        }
     except Exception as e:
         logger.exception("Delete by source failed")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -1604,10 +1704,19 @@ async def is_novel(request: IsNovelRequest):
 
 @app.get("/memories/count")
 async def count_memories(
+    request: Request,
     source: Optional[str] = Query(None, max_length=500),
 ):
     """Count memories, optionally filtered by source prefix."""
-    count = memory.count_memories(source_prefix=source)
+    auth = _get_auth(request)
+    if source and not auth.can_read(source):
+        raise HTTPException(status_code=403, detail=f"Key does not have read access to source: {source}")
+
+    if auth.prefixes is None:
+        count = memory.count_memories(source_prefix=source)
+    else:
+        scoped_count = _count_accessible_memories(auth, source_prefix=source)
+        count = scoped_count if scoped_count is not None else 0
     return {"count": count}
 
 
@@ -1620,8 +1729,15 @@ async def list_memories(
 ):
     """List memories with pagination and optional source filter"""
     auth = _get_auth(request)
+    if source and not auth.can_read(source):
+        raise HTTPException(status_code=403, detail=f"Key does not have read access to source: {source}")
+
     result = memory.list_memories(offset=offset, limit=limit, source_filter=source)
-    result["memories"] = auth.filter_results(result.get("memories", []))
+    filtered_memories = auth.filter_results(result.get("memories", []))
+    result["memories"] = filtered_memories
+    if auth.prefixes is not None:
+        scoped_total = _count_accessible_memories(auth, source_prefix=source)
+        result["total"] = scoped_total if scoped_total is not None else len(filtered_memories)
     return result
 
 
@@ -1728,8 +1844,10 @@ async def deduplicate(request_body: DeduplicateRequest, request: Request):
 # -- Backups ------------------------------------------------------------------
 
 @app.get("/backups")
-async def list_backups():
+async def list_backups(request: Request):
     """List available backups"""
+    auth = _get_auth(request)
+    _require_admin(auth)
     try:
         backups = sorted(
             memory.get_backup_dir().glob("*_*"), key=lambda p: p.name, reverse=True
@@ -2025,8 +2143,13 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
     auth = _get_auth(request)
     if request_body.source:
         _require_write(auth, request_body.source)
-    elif auth.role == "read-only":
-        raise HTTPException(status_code=403, detail="Read-only keys cannot trigger extraction")
+    else:
+        if auth.role == "read-only":
+            raise HTTPException(status_code=403, detail="Read-only keys cannot trigger extraction")
+        # Scoped non-admin keys must provide an explicit, writable source.
+        if auth.role != "admin" and auth.prefixes is not None:
+            raise HTTPException(status_code=400, detail="source is required for scoped keys")
+
     if extract_provider is None or run_extraction is None:
         if not EXTRACT_FALLBACK_ADD_ENABLED:
             raise HTTPException(status_code=501, detail="Extraction not configured. Set EXTRACT_PROVIDER env var.")
@@ -2041,6 +2164,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
             "created_at": _utc_now_iso(),
             "started_at": _utc_now_iso(),
             "mode": "fallback_add",
+            "auth_key_id": auth.key_id,
         }
         try:
             result = await run_in_threadpool(
@@ -2048,6 +2172,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
                 request_body.messages,
                 request_body.source,
                 request_body.context,
+                auth.prefixes,
             )
             extract_jobs[job_id]["status"] = "completed"
             extract_jobs[job_id]["completed_at"] = _utc_now_iso()
@@ -2085,6 +2210,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
         "context": request_body.context,
         "message_length": len(request_body.messages),
         "created_at": _utc_now_iso(),
+        "auth_key_id": auth.key_id,
     }
     try:
         extract_queue.put_nowait(
@@ -2094,6 +2220,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
                     "messages": request_body.messages,
                     "source": request_body.source,
                     "context": request_body.context,
+                    "allowed_prefixes": auth.prefixes,
                 },
             }
         )
@@ -2135,11 +2262,14 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
 
 
 @app.get("/memory/extract/{job_id}")
-async def memory_extract_job(job_id: str):
+async def memory_extract_job(job_id: str, request: Request):
     """Get queued extraction job status/result."""
+    auth = _get_auth(request)
     job = extract_jobs.get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Extraction job not found: {job_id}")
+    if not _can_access_extract_job(auth, job):
+        raise HTTPException(status_code=403, detail="Access denied to extraction job")
     return job
 
 

--- a/auth_context.py
+++ b/auth_context.py
@@ -45,11 +45,15 @@ class AuthContext:
     # -- permission checks ---------------------------------------------------
 
     def can_read(self, source: str) -> bool:
+        if self.role == "admin":
+            return True
         return self._matches_prefix(source)
 
     def can_write(self, source: str) -> bool:
         if self.role == "read-only":
             return False
+        if self.role == "admin":
+            return True
         return self._matches_prefix(source)
 
     @property

--- a/integrations/QUICKSTART-LLM.md
+++ b/integrations/QUICKSTART-LLM.md
@@ -27,6 +27,9 @@ grep -E '^(MEMORIES_URL|MEMORIES_API_KEY)=' ~/.config/memories/env 2>/dev/null |
 
 # 3. jq is installed
 jq --version
+
+# 4. Node/npm available for MCP server
+node --version && npm --version
 ```
 
 If the service isn't running:
@@ -160,6 +163,7 @@ cd ~/projects/memories
 ```
 
 This copies hook scripts to `~/.claude/hooks/memory/` and merges hook config into `~/.claude/settings.json`.
+It also writes Cursor MCP config at `~/.cursor/mcp.json` so tool calls work alongside hooks.
 
 ### Step 2: Enable Third-party skills in Cursor
 
@@ -170,6 +174,23 @@ That's it — Cursor will automatically load and run the memory hooks from `~/.c
 ### Manual setup (optional)
 
 Follow the Claude Code manual setup steps above (copy hooks, add env vars, edit `~/.claude/settings.json`), then enable Third-party skills in Cursor Settings.
+
+If you prefer MCP-only manual config, add this to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "memories": {
+      "command": "node",
+      "args": ["/path/to/memories/mcp-server/index.js"],
+      "env": {
+        "MEMORIES_URL": "http://localhost:8900",
+        "MEMORIES_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
 
 ---
 
@@ -184,6 +205,7 @@ Codex does **not** use Claude's 5-hook `settings.json` format. Codex-native inte
 
 ```bash
 cd ~/projects/memories
+cd mcp-server && npm install && cd ..
 ./integrations/claude-code/install.sh --codex
 ```
 
@@ -192,6 +214,10 @@ The installer will:
 2. Add `notify = ["/Users/you/.codex/hooks/memory/memory-codex-notify.sh"]` to `~/.codex/config.toml` when `notify` is not already set
 3. Add MCP server config for `memories` to `~/.codex/config.toml` when missing
 4. Add default `developer_instructions` (if not already set) to bias `memory_search` usage
+
+If `~/.codex/config.toml` already has `notify = [...]`, merge the Memories hook path into that existing list manually.
+The notify script loads `MEMORIES_URL` / `MEMORIES_API_KEY` from `~/.config/memories/env` (or `MEMORIES_ENV_FILE` override).
+For scoped API keys, set `MEMORIES_SOURCE_PREFIX` (or `MEMORIES_SOURCE`) so notify writes stay inside authorized prefixes.
 
 ### Option B: Manual setup
 
@@ -217,43 +243,17 @@ MEMORIES_URL = "http://localhost:8900"
 MEMORIES_API_KEY = "your-api-key-here"
 ```
 
+If your API key is prefix-scoped and does not allow `codex/*`, set one of these in `~/.config/memories/env`:
+
+```bash
+MEMORIES_SOURCE_PREFIX="your-authorized-prefix"
+# or exact source:
+# MEMORIES_SOURCE="your-authorized-prefix/your-project"
+```
+
 **Step 3: Restart Codex**
 
 Codex will expose `memory_search`, `memory_add`, `memory_delete`, `memory_delete_by_source`, `memory_count`, `memory_list`, `memory_stats`, `memory_is_novel`, and other tools via MCP.
-
----
-
-## Setup for Cursor
-
-Cursor is MCP-first today.
-
-1. Install MCP server deps:
-
-```bash
-cd ~/projects/memories/mcp-server
-npm install
-```
-
-2. Add config to one of:
-- Global: `~/.cursor/mcp.json`
-- Project: `.cursor/mcp.json`
-
-```json
-{
-  "mcpServers": {
-    "memories": {
-      "command": "node",
-      "args": ["/path/to/memories/mcp-server/index.js"],
-      "env": {
-        "MEMORIES_URL": "http://localhost:8900",
-        "MEMORIES_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}
-```
-
-3. Restart Cursor.
 
 ---
 
@@ -283,7 +283,7 @@ OpenClaw doesn't have hooks, so memory is agent-initiated via the skill. Update 
 
 | Mechanism | Event | What It Does |
 |-----------|-------|--------------|
-| `notify` + `memory-codex-notify.sh` | After each completed turn | Sends user+assistant exchange to `/memory/extract` (`context=after_agent`) |
+| `notify` + `memory-codex-notify.sh` | After each completed turn | Sends user+assistant exchange to `/memory/extract` (`context=after_agent`), handling snake/camel/kebab payloads and transcript fallback when available |
 | MCP tools + developer instructions | Each new user turn | Drives `memory_search` usage before implementation-heavy responses |
 
 Codex currently does not expose Claude-style SessionStart/UserPromptSubmit/PreCompact/SessionEnd hook callbacks in `config.toml`.
@@ -315,6 +315,9 @@ Codex currently does not expose Claude-style SessionStart/UserPromptSubmit/PreCo
 |----------|---------|-------------|
 | `MEMORIES_URL` | `http://localhost:8900` | Memories service URL |
 | `MEMORIES_API_KEY` | (empty) | API key for Memories service auth |
+| `MEMORIES_ENV_FILE` | `~/.config/memories/env` | Hook env file path for Claude/Codex notify scripts |
+| `MEMORIES_SOURCE_PREFIX` | `codex` (Codex notify) | Prefix used to build notify extraction source (`<prefix>/<project>`) |
+| `MEMORIES_SOURCE` | (empty) | Full source override for Codex notify extraction payloads |
 | `EXTRACT_PROVIDER` | (none) | `anthropic`, `openai`, `chatgpt-subscription`, `ollama`, or empty to disable |
 | `EXTRACT_MODEL` | (per provider) | Override model. Defaults: `claude-haiku-4-5-20251001`, `gpt-4.1-nano`, `gemma3:4b` |
 | `ANTHROPIC_API_KEY` | (none) | Required when `EXTRACT_PROVIDER=anthropic` |
@@ -421,7 +424,7 @@ rm -rf ~/.codex/hooks/memory/
 # - [mcp_servers.memories.env] section
 
 # Remove env vars from hook/repo env files
-# Edit ~/.config/memories/env and remove MEMORIES_URL/MEMORIES_API_KEY
+# Edit ~/.config/memories/env and remove MEMORIES_URL/MEMORIES_API_KEY/MEMORIES_SOURCE_PREFIX/MEMORIES_SOURCE
 # Edit ~/projects/memories/.env and remove EXTRACT_PROVIDER/provider keys
 ```
 

--- a/integrations/claude-code/install.sh
+++ b/integrations/claude-code/install.sh
@@ -505,16 +505,18 @@ developer_instructions = """
 Use the Memories MCP tools as your memory layer with three responsibilities:
 
 1. READ: Run memory_search before implementation-heavy responses or clarifying questions.
-2. WRITE: Use memory_add for single clear facts (check memory_is_novel first). Use memory_extract for rich conversations, decision changes, or deferred work updates — it handles Add/Update/Delete/Noop automatically via AUDN.
-3. MAINTAIN: Use memory_delete for explicit forget requests. memory_extract handles most lifecycle updates automatically.
+2. WRITE: Use memory_add for single clear facts (check memory_is_novel first). Use memory_extract for rich conversations, decision changes, or deferred work updates — it handles Add/Update/Delete/Noop automatically via AUDN. For scoped keys, always pass a non-empty source on memory_extract.
+3. MAINTAIN: Use memory_delete for explicit forget requests. memory_extract handles most lifecycle updates automatically. For bulk cleanup with scoped keys, prefer prefix-based deletion patterns that stay inside authorized sources.
 
-Source prefixes: codex/{project} for decisions, learning/{project} for fixes, wip/{project} for deferred work.
+Source prefixes: codex/{project} for decisions (or another authorized decision prefix when using scoped keys), learning/{project} for fixes, wip/{project} for deferred work.
 """
 EOF
 )
     append_marked_block "$codex_config" "$CODEX_DEV_INSTR_MARKER" "$dev_instructions_block"
     echo -e "  ${GREEN}[OK]${NC} Added Codex developer instructions in $codex_config"
   fi
+
+  echo -e "  ${YELLOW}[NOTE]${NC} Scoped-key tip: set MEMORIES_SOURCE_PREFIX (or MEMORIES_SOURCE) in ~/.config/memories/env if your key is restricted to non-codex prefixes."
 }
 
 if [ "$TARGET_CLAUDE" = true ]; then

--- a/integrations/codex/memory-codex-notify.sh
+++ b/integrations/codex/memory-codex-notify.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # memory-codex-notify.sh — Codex notify hook (after-agent)
-# Receives Codex legacy notify payload as argv[1] JSON and enqueues extraction.
+# Receives Codex notify payload as argv[1] JSON and enqueues extraction.
 
 set -euo pipefail
 
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+
 MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
 MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_SOURCE="${MEMORIES_SOURCE:-}"
+MEMORIES_SOURCE_PREFIX="${MEMORIES_SOURCE_PREFIX:-codex}"
 
 PAYLOAD="${1:-}"
 if [ -z "$PAYLOAD" ]; then
@@ -20,34 +24,167 @@ if ! echo "$PAYLOAD" | jq -e . >/dev/null 2>&1; then
   exit 0
 fi
 
-CWD=$(echo "$PAYLOAD" | jq -r '.cwd // "unknown"')
+EVENT_TYPE=$(echo "$PAYLOAD" | jq -r '.type // .event // ""')
+if [ -n "$EVENT_TYPE" ] && [ "$EVENT_TYPE" != "agent-turn-complete" ]; then
+  exit 0
+fi
+
+CWD=$(echo "$PAYLOAD" | jq -r '.cwd // .workspace_roots[0] // .workspaceRoots[0] // .workspace.root // .workspaceRoot // "unknown"')
 PROJECT=$(basename "$CWD")
+if [ -z "$PROJECT" ] || [ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ]; then
+  PROJECT="unknown"
+fi
 
-USER_LINES=$(echo "$PAYLOAD" | jq -r '
-  (."input-messages" // .input_messages // [])
-  | map(select(type == "string" and length > 0))
-  | map("User: " + .)
-  | join("\n")
-')
-ASSISTANT_LINE=$(echo "$PAYLOAD" | jq -r '
-  (."last-assistant-message" // .last_assistant_message // "")
-  | if type == "string" then . else "" end
-')
+TRANSCRIPT_PATH=$(echo "$PAYLOAD" | jq -r '.transcript_path // .transcriptPath // empty')
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
-MESSAGES="$USER_LINES"
-if [ -n "$ASSISTANT_LINE" ]; then
-  if [ -n "$MESSAGES" ]; then
-    MESSAGES="$MESSAGES"$'\n'
+MESSAGES=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  MESSAGES=$(tail -300 "$TRANSCRIPT_PATH" 2>/dev/null | jq -sr '
+    def textify:
+      if . == null then ""
+      elif type == "string" then .
+      elif type == "number" or type == "boolean" then tostring
+      elif type == "array" then
+        [
+          .[]
+          | if type == "object" then
+              if ((.type // "") | tostring) == "text" and ((.text // null) | type) == "string" then .text
+              elif ((.text // null) | type) == "string" then .text
+              elif ((.content // null) | type) == "string" then .content
+              elif (.content // null) != null then (.content | textify)
+              elif ((.message // null) | type) == "string" then .message
+              else "" end
+            elif type == "string" then .
+            else "" end
+        ]
+        | map(select(length > 0))
+        | join(" ")
+      elif type == "object" then
+        if (.content // null) != null then (.content | textify)
+        elif ((.text // null) | type) == "string" then .text
+        elif ((.message // null) | type) == "string" then .message
+        else "" end
+      else "" end;
+    [
+      .[]
+      | {
+          role: ((.type // .message.role // "") | tostring),
+          text: ((.message.content // .content // .text // .message // null) | textify)
+        }
+      | select((.role == "user" or .role == "assistant") and ((.text | length) > 10))
+    ]
+    | .[-2:]
+    | map(
+        (if .role == "user" then "User: " else "Assistant: " end) +
+        (
+          .text
+          | gsub("[\\r\\n]+"; " ")
+          | gsub("\\s+"; " ")
+          | gsub("^\\s+|\\s+$"; "")
+          | .[0:2000]
+        )
+      )
+    | join("\n")
+  ' 2>/dev/null) || true
+fi
+
+if [ -z "$MESSAGES" ] || [ "$MESSAGES" = "null" ]; then
+  USER_LINES=$(echo "$PAYLOAD" | jq -r '
+    def textify:
+      if . == null then ""
+      elif type == "string" then .
+      elif type == "number" or type == "boolean" then tostring
+      elif type == "array" then
+        [
+          .[]
+          | if type == "object" then
+              if ((.type // "") | tostring) == "text" and ((.text // null) | type) == "string" then .text
+              elif ((.text // null) | type) == "string" then .text
+              elif (.content // null) != null then (.content | textify)
+              elif ((.message // null) | type) == "string" then .message
+              else "" end
+            elif type == "string" then .
+            else "" end
+        ]
+        | map(select(length > 0))
+        | join(" ")
+      elif type == "object" then
+        if (.content // null) != null then (.content | textify)
+        elif ((.text // null) | type) == "string" then .text
+        elif ((.message // null) | type) == "string" then .message
+        else "" end
+      else "" end;
+    (."input-messages" // .input_messages // .inputMessages // .messages // [])
+    | if type == "array" then . else [.] end
+    | map(
+        textify
+        | gsub("[\\r\\n]+"; " ")
+        | gsub("\\s+"; " ")
+        | gsub("^\\s+|\\s+$"; "")
+      )
+    | map(select(length > 0))
+    | map("User: " + (.[0:2000]))
+    | join("\n")
+  ')
+  ASSISTANT_LINE=$(echo "$PAYLOAD" | jq -r '
+    def textify:
+      if . == null then ""
+      elif type == "string" then .
+      elif type == "number" or type == "boolean" then tostring
+      elif type == "array" then
+        [
+          .[]
+          | if type == "object" then
+              if ((.type // "") | tostring) == "text" and ((.text // null) | type) == "string" then .text
+              elif ((.text // null) | type) == "string" then .text
+              elif (.content // null) != null then (.content | textify)
+              elif ((.message // null) | type) == "string" then .message
+              else "" end
+            elif type == "string" then .
+            else "" end
+        ]
+        | map(select(length > 0))
+        | join(" ")
+      elif type == "object" then
+        if (.content // null) != null then (.content | textify)
+        elif ((.text // null) | type) == "string" then .text
+        elif ((.message // null) | type) == "string" then .message
+        else "" end
+      else "" end;
+    (."last-assistant-message" // .last_assistant_message // .lastAssistantMessage // .assistant // .response // "")
+    | textify
+    | gsub("[\\r\\n]+"; " ")
+    | gsub("\\s+"; " ")
+    | gsub("^\\s+|\\s+$"; "")
+    | .[0:2000]
+  ')
+
+  MESSAGES="$USER_LINES"
+  if [ -n "$ASSISTANT_LINE" ]; then
+    if [ -n "$MESSAGES" ]; then
+      MESSAGES="$MESSAGES"$'\n'
+    fi
+    MESSAGES="$MESSAGES""Assistant: $ASSISTANT_LINE"
   fi
-  MESSAGES="$MESSAGES""Assistant: $ASSISTANT_LINE"
 fi
 
 if [ -z "$MESSAGES" ]; then
   exit 0
 fi
+MESSAGES="${MESSAGES:0:4000}"
 
-BODY=$(jq -nc --arg msgs "$MESSAGES" --arg src "codex/$PROJECT" '{"messages": $msgs, "source": $src, "context": "after_agent"}')
-curl -sf -X POST "$MEMORIES_URL/memory/extract" \
+SOURCE="$MEMORIES_SOURCE"
+if [ -z "$SOURCE" ]; then
+  SOURCE_PREFIX="${MEMORIES_SOURCE_PREFIX%/}"
+  if [ -z "$SOURCE_PREFIX" ]; then
+    SOURCE_PREFIX="codex"
+  fi
+  SOURCE="$SOURCE_PREFIX/$PROJECT"
+fi
+
+BODY=$(jq -nc --arg msgs "$MESSAGES" --arg src "$SOURCE" '{"messages": $msgs, "source": $src, "context": "after_agent"}')
+curl -sf --connect-timeout 1 --max-time 2 -X POST "$MEMORIES_URL/memory/extract" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $MEMORIES_API_KEY" \
   -d "$BODY" \

--- a/llm_extract.py
+++ b/llm_extract.py
@@ -10,7 +10,7 @@ Usage:
 import json
 import logging
 import os
-from typing import Optional
+from typing import Optional, List
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,19 @@ EXTRACT_MAX_FACTS = _env_int("EXTRACT_MAX_FACTS", 30)
 EXTRACT_MAX_FACT_CHARS = _env_int("EXTRACT_MAX_FACT_CHARS", 500, minimum=40)
 EXTRACT_SIMILAR_TEXT_CHARS = _env_int("EXTRACT_SIMILAR_TEXT_CHARS", 280, minimum=40)
 EXTRACT_SIMILAR_PER_FACT = _env_int("EXTRACT_SIMILAR_PER_FACT", 5)
+
+
+def _source_matches_prefixes(source: str, prefixes: Optional[List[str]]) -> bool:
+    """Return True when source is allowed by managed-key prefixes."""
+    if prefixes is None:
+        return True
+    if ".." in source.split("/"):
+        return False
+    for pfx in prefixes:
+        base = pfx.rstrip("/").removesuffix("/*").rstrip("/")
+        if source == base or source.startswith(base + "/"):
+            return True
+    return False
 
 # --- Prompts ---
 
@@ -209,7 +222,13 @@ def extract_facts(
         return []
 
 
-def run_audn(provider, engine, facts: list[dict], source: str) -> tuple[list[dict], dict]:
+def run_audn(
+    provider,
+    engine,
+    facts: list[dict],
+    source: str,
+    allowed_prefixes: Optional[List[str]] = None,
+) -> tuple[list[dict], dict]:
     """Run AUDN cycle on extracted facts.
 
     For providers with supports_audn=True: uses LLM to decide action per fact.
@@ -241,6 +260,11 @@ def run_audn(provider, engine, facts: list[dict], source: str) -> tuple[list[dic
         fact_text = fact["text"] if isinstance(fact, dict) else str(fact)
         try:
             results = engine.hybrid_search(fact_text, k=EXTRACT_SIMILAR_PER_FACT)
+            if allowed_prefixes is not None:
+                results = [
+                    r for r in results
+                    if _source_matches_prefixes(str(r.get("source", "")), allowed_prefixes)
+                ]
             similar_per_fact[i] = results
         except Exception:
             similar_per_fact[i] = []
@@ -282,7 +306,13 @@ def run_audn(provider, engine, facts: list[dict], source: str) -> tuple[list[dic
         return [{"action": "ADD", "fact_index": i} for i in range(len(facts))], {"input": 0, "output": 0}
 
 
-def execute_actions(engine, actions: list[dict], facts: list[dict], source: str) -> dict:
+def execute_actions(
+    engine,
+    actions: list[dict],
+    facts: list[dict],
+    source: str,
+    allowed_prefixes: Optional[List[str]] = None,
+) -> dict:
     """Execute AUDN decisions against the memory engine.
 
     Args:
@@ -301,6 +331,8 @@ def execute_actions(engine, actions: list[dict], facts: list[dict], source: str)
 
         try:
             if act == "ADD":
+                if not _source_matches_prefixes(source, allowed_prefixes):
+                    raise PermissionError(f"source not authorized for add: {source}")
                 fact_meta = {"category": fact.get("category", "detail")} if isinstance(fact, dict) else {}
                 added_ids = engine.add_memories(
                     texts=[fact_text],
@@ -315,6 +347,13 @@ def execute_actions(engine, actions: list[dict], facts: list[dict], source: str)
             elif act == "UPDATE":
                 old_id = action.get("old_id")
                 new_text = action.get("new_text", fact_text)
+                if old_id is not None and allowed_prefixes is not None:
+                    existing = engine.get_memory(old_id)
+                    existing_source = str(existing.get("source", ""))
+                    if not _source_matches_prefixes(existing_source, allowed_prefixes):
+                        raise PermissionError(f"old_id not authorized for update: {old_id}")
+                if not _source_matches_prefixes(source, allowed_prefixes):
+                    raise PermissionError(f"source not authorized for update: {source}")
                 if old_id is not None:
                     engine.delete_memory(old_id)
                 fact_meta = {"category": fact.get("category", "detail"), "supersedes": old_id} if isinstance(fact, dict) else {"supersedes": old_id}
@@ -331,6 +370,11 @@ def execute_actions(engine, actions: list[dict], facts: list[dict], source: str)
             elif act == "DELETE":
                 old_id = action.get("old_id")
                 if old_id is not None:
+                    if allowed_prefixes is not None:
+                        existing = engine.get_memory(old_id)
+                        existing_source = str(existing.get("source", ""))
+                        if not _source_matches_prefixes(existing_source, allowed_prefixes):
+                            raise PermissionError(f"old_id not authorized for delete: {old_id}")
                     engine.delete_memory(old_id)
                     result_actions.append({"action": "delete", "old_id": old_id})
                     deleted_count += 1
@@ -356,7 +400,8 @@ def run_extraction(
     engine,
     messages: str,
     source: str,
-    context: str = "stop"
+    context: str = "stop",
+    allowed_prefixes: Optional[List[str]] = None,
 ) -> dict:
     """Full extraction pipeline: extract facts -> AUDN -> execute.
 
@@ -404,10 +449,22 @@ def run_extraction(
         }
 
     # Step 2: AUDN decisions
-    decisions, audn_tokens = run_audn(provider, engine, facts, source)
+    decisions, audn_tokens = run_audn(
+        provider,
+        engine,
+        facts,
+        source,
+        allowed_prefixes=allowed_prefixes,
+    )
 
     # Step 3: Execute
-    result = execute_actions(engine, decisions, facts, source)
+    result = execute_actions(
+        engine,
+        decisions,
+        facts,
+        source,
+        allowed_prefixes=allowed_prefixes,
+    )
     result["extracted_count"] = len(facts)
     result["tokens"] = {"extract": extract_tokens, "audn": audn_tokens}
 

--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -17,8 +17,8 @@ description: >-
 
 You have access to a persistent, semantically searchable memory system via Memories MCP.
 This skill teaches you *when* and *how* to use it effectively. It complements — but does
-not replace — CC's built-in auto-memory (which handles project conventions passively) and
-session hooks (which provide baseline context at startup).
+not replace — the assistant's built-in auto-memory (which handles project conventions
+passively) and lifecycle hooks (which provide baseline context at startup).
 
 Your job is the judgment layer: deciding what's worth storing, when to store it, when
 to actively search for context, and when to trigger lifecycle operations.
@@ -120,6 +120,7 @@ situations need direct action.
   then delete by ID with `memory_delete`
 - Project sunset or namespace cleanup → `memory_delete_by_source` with the project prefix
 - Bulk cleanup of stale wip/ items → `memory_delete_by_source` with `wip/{project}`
+- For scoped API keys, ensure any bulk delete source prefix is inside authorized prefixes
 
 **When AUDN handles it for you:**
 - Decision reversed → `memory_extract` with the new context. AUDN sees the old decision
@@ -140,12 +141,14 @@ Use consistent prefixes so memories can be found and cleaned up by scope:
 
 | Prefix | Use for |
 |--------|---------|
-| `claude-code/{project}` | Code decisions, architecture choices, project-specific context |
+| `claude-code/{project}` or `codex/{project}` | Code decisions, architecture choices, project-specific context (choose the client prefix you run under) |
 | `learning/{project}` | Discovered patterns, gotchas, fixes, non-obvious behaviors |
 | `wip/{project}` | Deferred work, open threads, "revisit later" items |
 
 Never invent ad-hoc prefixes like `myapp/decisions` or `myapp/deployment`. Stick to
 these three categories — they enable reliable search and cleanup by scope.
+If your key is prefix-scoped, `source` must be non-empty and inside those authorized
+prefixes.
 
 ### Format
 

--- a/tests/test_auth_backward_compat.py
+++ b/tests/test_auth_backward_compat.py
@@ -1,6 +1,7 @@
 """Backward compatibility -- existing single-key setups must work unchanged."""
 import importlib
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +23,7 @@ def single_key_client():
         mock_engine.is_ready.return_value = {"ready": True}
         mock_engine.count_memories.return_value = 5
         mock_engine.list_memories.return_value = {"memories": [], "total": 0}
+        mock_engine.get_backup_dir.return_value = Path("/tmp")
         app_module.memory = mock_engine
         yield TestClient(app_module.app), mock_engine
 
@@ -40,6 +42,7 @@ def no_auth_client():
         mock_engine.is_ready.return_value = {"ready": True}
         mock_engine.count_memories.return_value = 0
         mock_engine.list_memories.return_value = {"memories": [], "total": 0}
+        mock_engine.get_backup_dir.return_value = Path("/tmp")
         app_module.memory = mock_engine
         yield TestClient(app_module.app), mock_engine
 
@@ -100,6 +103,16 @@ class TestSingleKeyBackwardCompat:
         assert body["role"] == "admin"
         assert body["type"] == "env"
 
+    def test_existing_key_can_access_usage(self, single_key_client):
+        client, _ = single_key_client
+        resp = client.get("/usage", headers={"X-API-Key": "god-is-an-astronaut"})
+        assert resp.status_code == 200
+
+    def test_existing_key_can_access_backups(self, single_key_client):
+        client, _ = single_key_client
+        resp = client.get("/backups", headers={"X-API-Key": "god-is-an-astronaut"})
+        assert resp.status_code == 200
+
 
 class TestNoAuthBackwardCompat:
     def test_no_key_needed_for_search(self, no_auth_client):
@@ -123,4 +136,9 @@ class TestNoAuthBackwardCompat:
     def test_health_works(self, no_auth_client):
         client, _ = no_auth_client
         resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_no_key_needed_for_usage_local_mode(self, no_auth_client):
+        client, _ = no_auth_client
+        resp = client.get("/usage")
         assert resp.status_code == 200

--- a/tests/test_codex_notify_hook.py
+++ b/tests/test_codex_notify_hook.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import threading
-from contextlib import contextmanager
-from http.server import BaseHTTPRequestHandler
-from socketserver import TCPServer
 from pathlib import Path
 
 
@@ -20,58 +16,79 @@ SCRIPT = (
 )
 
 
-@contextmanager
-def _capture_server():
-    requests: list[dict[str, object]] = []
+def _write_fake_curl(bin_dir: Path) -> Path:
+    script = bin_dir / "curl"
+    script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
 
-    class Handler(BaseHTTPRequestHandler):
-        def do_POST(self) -> None:  # noqa: N802
-            content_length = int(self.headers.get("Content-Length", "0"))
-            body = self.rfile.read(content_length).decode("utf-8")
-            requests.append(
-                {
-                    "path": self.path,
-                    "headers": dict(self.headers.items()),
-                    "body": body,
-                }
-            )
-            self.send_response(202)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(b'{"job_id":"job-1"}')
+: "${FAKE_CURL_ARGS:?}"
+: "${FAKE_CURL_BODY:?}"
 
-        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
-            return
+: > "$FAKE_CURL_ARGS"
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$FAKE_CURL_ARGS"
+done
 
-    with TCPServer(("127.0.0.1", 0), Handler) as server:
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-        try:
-            host, port = server.server_address
-            yield f"http://{host}:{port}", requests
-        finally:
-            server.shutdown()
-            thread.join()
+body=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d|--data|--data-raw|--data-binary)
+      shift
+      body="${1:-}"
+      ;;
+  esac
+  shift || true
+done
+
+printf '%s' "$body" > "$FAKE_CURL_BODY"
+printf '{"job_id":"job-1"}\n'
+"""
+    )
+    script.chmod(0o755)
+    return script
 
 
-def _run_hook(memories_url: str, payload: dict[str, object], api_key: str = "") -> subprocess.CompletedProcess[str]:
+def _run_hook(
+    tmp_path: Path,
+    payload: dict[str, object],
+    *,
+    memories_url: str = "http://127.0.0.1:9999",
+    api_key: str = "",
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    args_file = tmp_path / "curl-args.txt"
+    body_file = tmp_path / "curl-body.txt"
+
     env = os.environ.copy()
     env.update(
         {
             "MEMORIES_URL": memories_url,
             "MEMORIES_API_KEY": api_key,
+            "MEMORIES_ENV_FILE": str(tmp_path / "no-hook-env"),
+            "FAKE_CURL_ARGS": str(args_file),
+            "FAKE_CURL_BODY": str(body_file),
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
         }
     )
-    return subprocess.run(
+    if extra_env:
+        env.update(extra_env)
+
+    result = subprocess.run(
         [str(SCRIPT), json.dumps(payload)],
         text=True,
         capture_output=True,
         env=env,
         check=False,
     )
+    return result, args_file, body_file, bin_dir
 
 
-def test_codex_notify_posts_extraction_payload() -> None:
+def test_codex_notify_posts_extraction_payload(tmp_path: Path) -> None:
     assert SCRIPT.exists(), f"missing script: {SCRIPT}"
 
     payload = {
@@ -83,17 +100,17 @@ def test_codex_notify_posts_extraction_payload() -> None:
         "last-assistant-message": "done, updated docker compose and docs",
     }
 
-    with _capture_server() as (memories_url, requests):
-        result = _run_hook(memories_url, payload, api_key="abc123")
+    result, args_file, body_file, _ = _run_hook(tmp_path, payload, api_key="abc123")
 
     assert result.returncode == 0
-    assert len(requests) == 1
-    request = requests[0]
-    assert request["path"] == "/memory/extract"
-    headers = request["headers"]
-    assert headers.get("X-API-Key") == "abc123"
+    assert args_file.exists()
+    assert body_file.exists()
 
-    body = json.loads(str(request["body"]))
+    args_text = args_file.read_text()
+    assert "http://127.0.0.1:9999/memory/extract" in args_text
+    assert "X-API-Key: abc123" in args_text
+
+    body = json.loads(body_file.read_text())
     assert body["context"] == "after_agent"
     assert body["source"] == "codex/memories"
     assert "User: use qdrant in prod" in body["messages"]
@@ -101,7 +118,7 @@ def test_codex_notify_posts_extraction_payload() -> None:
     assert "Assistant: done, updated docker compose and docs" in body["messages"]
 
 
-def test_codex_notify_skips_when_no_messages() -> None:
+def test_codex_notify_skips_when_no_messages(tmp_path: Path) -> None:
     assert SCRIPT.exists(), f"missing script: {SCRIPT}"
 
     payload = {
@@ -113,8 +130,117 @@ def test_codex_notify_skips_when_no_messages() -> None:
         "last-assistant-message": "",
     }
 
-    with _capture_server() as (memories_url, requests):
-        result = _run_hook(memories_url, payload)
+    result, args_file, body_file, _ = _run_hook(tmp_path, payload)
 
     assert result.returncode == 0
-    assert requests == []
+    assert not args_file.exists()
+    assert not body_file.exists()
+
+
+def test_codex_notify_supports_camel_case_and_object_messages(tmp_path: Path) -> None:
+    payload = {
+        "type": "agent-turn-complete",
+        "workspaceRoots": ["/Users/example/agent-project"],
+        "inputMessages": [
+            {"content": [{"type": "text", "text": "remember db migration order"}]}
+        ],
+        "lastAssistantMessage": {
+            "content": [
+                {"type": "text", "text": "captured and updated docs"},
+            ]
+        },
+    }
+
+    result, _, body_file, _ = _run_hook(tmp_path, payload)
+
+    assert result.returncode == 0
+    body = json.loads(body_file.read_text())
+    assert body["source"] == "codex/agent-project"
+    assert "User: remember db migration order" in body["messages"]
+    assert "Assistant: captured and updated docs" in body["messages"]
+
+
+def test_codex_notify_uses_transcript_when_available(tmp_path: Path) -> None:
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": "ship with qdrant and sqlite fallback"
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "implemented with feature flag"}
+                            ]
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    payload = {
+        "type": "agent-turn-complete",
+        "cwd": "/Users/example/memories",
+        "transcript_path": str(transcript),
+        "input-messages": [],
+        "last-assistant-message": "",
+    }
+
+    result, _, body_file, _ = _run_hook(tmp_path, payload)
+
+    assert result.returncode == 0
+    body = json.loads(body_file.read_text())
+    assert "User: ship with qdrant and sqlite fallback" in body["messages"]
+    assert "Assistant: implemented with feature flag" in body["messages"]
+
+
+def test_codex_notify_honors_source_env_overrides(tmp_path: Path) -> None:
+    payload = {
+        "type": "agent-turn-complete",
+        "cwd": "/Users/example/memories",
+        "input-messages": ["remember this source behavior"],
+        "last-assistant-message": "",
+    }
+
+    prefix_result, _, prefix_body_file, _ = _run_hook(
+        tmp_path / "prefix",
+        payload,
+        extra_env={"MEMORIES_SOURCE_PREFIX": "claude-code/"},
+    )
+    assert prefix_result.returncode == 0
+    prefix_body = json.loads(prefix_body_file.read_text())
+    assert prefix_body["source"] == "claude-code/memories"
+
+    full_result, _, full_body_file, _ = _run_hook(
+        tmp_path / "full",
+        payload,
+        extra_env={"MEMORIES_SOURCE": "tenant-a/project-x"},
+    )
+    assert full_result.returncode == 0
+    full_body = json.loads(full_body_file.read_text())
+    assert full_body["source"] == "tenant-a/project-x"
+
+
+def test_codex_notify_skips_non_turn_events(tmp_path: Path) -> None:
+    payload = {
+        "type": "session-start",
+        "cwd": "/Users/example/memories",
+        "input-messages": ["this should be ignored"],
+        "last-assistant-message": "ignored",
+    }
+
+    result, args_file, body_file, _ = _run_hook(tmp_path, payload)
+
+    assert result.returncode == 0
+    assert not args_file.exists()
+    assert not body_file.exists()

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -341,6 +341,32 @@ class TestAUDNCycle:
         prompt = mock_provider.complete.call_args[0][1]
         assert '"category":"decision"' in prompt
 
+    def test_audn_filters_similar_memories_by_allowed_prefixes(self):
+        from llm_extract import run_audn
+
+        mock_provider = MagicMock()
+        mock_provider.supports_audn = True
+        mock_provider.complete.return_value = _cr(json.dumps([
+            {"action": "ADD", "fact_index": 0}
+        ]))
+
+        mock_engine = MagicMock()
+        mock_engine.hybrid_search.return_value = [
+            {"id": 1, "text": "Allowed", "source": "claude-code/proj", "similarity": 0.9},
+            {"id": 2, "text": "Blocked", "source": "other/secret", "similarity": 0.95},
+        ]
+
+        run_audn(
+            mock_provider, mock_engine,
+            facts=[{"text": "Uses Drizzle ORM", "category": "decision"}],
+            source="claude-code/proj",
+            allowed_prefixes=["claude-code/*"],
+        )
+
+        prompt = mock_provider.complete.call_args[0][1]
+        assert "Allowed" in prompt
+        assert "Blocked" not in prompt
+
 
 class TestExecuteActions:
     """Test execute_actions() function."""
@@ -427,6 +453,45 @@ class TestExecuteActions:
         call_kwargs = mock_engine.add_memories.call_args
         # Out-of-bounds should use default empty text
         assert call_kwargs.kwargs.get("texts") == [""]
+
+    def test_execute_update_skips_disallowed_old_id(self):
+        from llm_extract import execute_actions
+
+        mock_engine = MagicMock()
+        mock_engine.get_memory.return_value = {"id": 42, "source": "other/secret", "text": "old"}
+        actions = [{"action": "UPDATE", "fact_index": 0, "old_id": 42, "new_text": "updated text"}]
+        facts = [{"text": "original fact", "category": "decision"}]
+
+        result = execute_actions(
+            mock_engine,
+            actions,
+            facts,
+            source="claude-code/proj",
+            allowed_prefixes=["claude-code/*"],
+        )
+        assert result["updated_count"] == 0
+        mock_engine.delete_memory.assert_not_called()
+        mock_engine.add_memories.assert_not_called()
+        assert any(a.get("action") == "error" for a in result["actions"])
+
+    def test_execute_delete_skips_disallowed_old_id(self):
+        from llm_extract import execute_actions
+
+        mock_engine = MagicMock()
+        mock_engine.get_memory.return_value = {"id": 55, "source": "other/secret", "text": "old"}
+        actions = [{"action": "DELETE", "fact_index": 0, "old_id": 55}]
+        facts = [{"text": "contradicted fact", "category": "detail"}]
+
+        result = execute_actions(
+            mock_engine,
+            actions,
+            facts,
+            source="claude-code/proj",
+            allowed_prefixes=["claude-code/*"],
+        )
+        assert result["deleted_count"] == 0
+        mock_engine.delete_memory.assert_not_called()
+        assert any(a.get("action") == "error" for a in result["actions"])
 
 
 class TestFullPipeline:

--- a/tests/test_multi_auth.py
+++ b/tests/test_multi_auth.py
@@ -2,6 +2,7 @@
 import importlib
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +24,19 @@ def app_with_keys():
             mock_engine.search.return_value = []
             mock_engine.hybrid_search.return_value = []
             mock_engine.is_ready.return_value = {"ready": True}
+            mock_engine.count_memories.return_value = 0
+            mock_engine.list_memories.return_value = {
+                "memories": [],
+                "total": 0,
+                "offset": 0,
+                "limit": 20,
+            }
+            mock_engine.delete_memories.return_value = {
+                "deleted_count": 0,
+                "deleted_ids": [],
+                "missing_ids": [],
+            }
+            mock_engine.metadata = []
             app_module.memory = mock_engine
 
             from key_store import KeyStore
@@ -275,3 +289,136 @@ class TestSupersedeAuthCheck:
             headers={"X-API-Key": created["key"]},
         )
         assert resp.status_code == 403
+
+
+class TestScopedSecurityHardening:
+    def test_extract_requires_source_for_scoped_key(self, app_with_keys):
+        client, _, key_store = app_with_keys
+        created = key_store.create_key(name="writer", role="read-write", prefixes=["claude-code/*"])
+        resp = client.post(
+            "/memory/extract",
+            json={"messages": "User: decided to use postgres", "context": "stop"},
+            headers={"X-API-Key": created["key"]},
+        )
+        assert resp.status_code == 400
+        assert "source is required" in resp.json()["detail"]
+
+    def test_delete_by_source_scoped_key_only_deletes_authorized_sources(self, app_with_keys):
+        client, mock_engine, key_store = app_with_keys
+        mock_engine.metadata = [
+            {"id": 1, "source": "claude-code/app", "text": "allowed"},
+            {"id": 2, "source": "other/claude-code/secret", "text": "blocked"},
+        ]
+        mock_engine.delete_memories.return_value = {
+            "deleted_count": 1,
+            "deleted_ids": [1],
+            "missing_ids": [],
+        }
+        created = key_store.create_key(name="writer", role="read-write", prefixes=["claude-code/*"])
+
+        resp = client.post(
+            "/memory/delete-by-source",
+            json={"source_pattern": "claude-code"},
+            headers={"X-API-Key": created["key"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["deleted_count"] == 1
+        mock_engine.delete_memories.assert_called_once_with([1])
+        mock_engine.delete_by_source.assert_not_called()
+
+    def test_delete_by_source_admin_keeps_legacy_behavior(self, app_with_keys):
+        client, mock_engine, _ = app_with_keys
+        mock_engine.delete_by_source.return_value = {"deleted_count": 2}
+        resp = client.post(
+            "/memory/delete-by-source",
+            json={"source_pattern": "claude-code"},
+            headers={"X-API-Key": "admin-env-key"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["deleted_count"] == 2
+        mock_engine.delete_by_source.assert_called_once_with("claude-code")
+        mock_engine.delete_memories.assert_not_called()
+
+    def test_memories_count_is_scoped(self, app_with_keys):
+        client, mock_engine, key_store = app_with_keys
+        mock_engine.metadata = [
+            {"id": 1, "source": "claude-code/a"},
+            {"id": 2, "source": "other/b"},
+            {"id": 3, "source": "claude-code/c"},
+        ]
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+
+        resp = client.get("/memories/count", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+        mock_engine.count_memories.assert_not_called()
+
+    def test_memories_count_rejects_disallowed_source_filter(self, app_with_keys):
+        client, _, key_store = app_with_keys
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+        resp = client.get("/memories/count?source=other/", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 403
+
+    def test_memories_list_total_is_scoped(self, app_with_keys):
+        client, mock_engine, key_store = app_with_keys
+        mock_engine.list_memories.return_value = {
+            "memories": [
+                {"id": 1, "source": "claude-code/a", "text": "a"},
+                {"id": 2, "source": "other/b", "text": "b"},
+            ],
+            "total": 2,
+            "offset": 0,
+            "limit": 20,
+        }
+        mock_engine.metadata = [
+            {"id": 1, "source": "claude-code/a"},
+            {"id": 2, "source": "other/b"},
+            {"id": 3, "source": "claude-code/c"},
+        ]
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+        resp = client.get("/memories", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        assert len(body["memories"]) == 1
+        assert body["memories"][0]["source"] == "claude-code/a"
+
+    def test_memories_list_rejects_disallowed_source_filter(self, app_with_keys):
+        client, _, key_store = app_with_keys
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+        resp = client.get("/memories?source=other/", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 403
+
+    def test_usage_requires_admin(self, app_with_keys):
+        client, _, key_store = app_with_keys
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+        resp = client.get("/usage", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 403
+
+    def test_backups_requires_admin(self, app_with_keys):
+        client, mock_engine, key_store = app_with_keys
+        mock_engine.get_backup_dir.return_value = Path("/tmp")
+        created = key_store.create_key(name="reader", role="read-only", prefixes=["claude-code/*"])
+        resp = client.get("/backups", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 403
+
+    def test_extract_job_visibility_is_source_scoped(self, app_with_keys):
+        client, mock_engine, key_store = app_with_keys
+        mock_engine.is_novel.return_value = (False, {"id": 1, "similarity": 0.99})
+        with patch("app.extract_provider", None), patch("app.run_extraction", None), patch("app.EXTRACT_FALLBACK_ADD_ENABLED", True):
+            creator = key_store.create_key(name="creator", role="read-write", prefixes=["claude-code/*"])
+            outsider = key_store.create_key(name="outsider", role="read-write", prefixes=["other/*"])
+
+            create_resp = client.post(
+                "/memory/extract",
+                json={"messages": "User: remember this decision", "source": "claude-code/proj", "context": "stop"},
+                headers={"X-API-Key": creator["key"]},
+            )
+            assert create_resp.status_code == 202
+            job_id = create_resp.json()["job_id"]
+
+            denied = client.get(f"/memory/extract/{job_id}", headers={"X-API-Key": outsider["key"]})
+            assert denied.status_code == 403
+
+            allowed = client.get(f"/memory/extract/{job_id}", headers={"X-API-Key": creator["key"]})
+            assert allowed.status_code == 200

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -26,7 +26,8 @@ def client():
 def test_ui_page_is_served_without_api_key_header(client):
     response = client.get("/ui")
     assert response.status_code == 200
-    assert "Memory Observatory" in response.text
+    assert "<title>Memories</title>" in response.text
+    assert "Dashboard" in response.text
 
 
 def test_ui_static_assets_are_served(client):
@@ -34,9 +35,9 @@ def test_ui_static_assets_are_served(client):
     js_response = client.get("/ui/static/app.js")
 
     assert css_response.status_code == 200
-    assert "--accent" in css_response.text
+    assert "--color-primary" in css_response.text
 
     assert js_response.status_code == 200
     assert "loadMemories" in js_response.text
-    assert "syncApiKeyFromInput" in js_response.text
-    assert "addEventListener(\"input\"" in js_response.text
+    assert "syncKeyStatus" in js_response.text
+    assert "addEventListener(\"keydown\"" in js_response.text


### PR DESCRIPTION
## Summary
- hardens scoped auth paths for extract/list/count/delete and admin-only usage/backups endpoints while preserving backward compatibility
- aligns Codex notify behavior with Claude-style robustness (payload variants, transcript fallback, source override env vars for scoped keys)
- updates installer/developer instructions and setup docs (README, GETTING_STARTED, QUICKSTART-LLM, changelog, skill guidance)
- adds/updates TDD coverage across auth, extraction, codex notify, installer, and UI smoke expectations

## Validation
- .venv/bin/python -m pytest -q
- result: 594 passed

## Notes
- no merge performed; PR is ready for developer validation