### PR TITLE
Expose extraction categories in result actions

### DIFF
--- a/llm_extract.py
+++ b/llm_extract.py
@@ -337,6 +337,11 @@ def execute_actions(
     deleted_count = 0
     result_actions = []
 
+    def _result_category(fact: dict | str) -> str:
+        if not isinstance(fact, dict):
+            return "DETAIL"
+        return str(fact.get("category", "detail")).upper()
+
     for action in actions:
         act = action.get("action", "").upper()
         fi = action.get("fact_index", -1)
@@ -355,7 +360,14 @@ def execute_actions(
                     deduplicate=True,
                 )
                 new_id = added_ids[0] if added_ids else None
-                result_actions.append({"action": "add", "text": fact_text, "id": new_id})
+                result_actions.append(
+                    {
+                        "action": "add",
+                        "text": fact_text,
+                        "id": new_id,
+                        "category": _result_category(fact),
+                    }
+                )
                 stored_count += 1
 
             elif act == "UPDATE":
@@ -378,7 +390,15 @@ def execute_actions(
                     deduplicate=False,
                 )
                 new_id = added_ids[0] if added_ids else None
-                result_actions.append({"action": "update", "old_id": old_id, "text": new_text, "new_id": new_id})
+                result_actions.append(
+                    {
+                        "action": "update",
+                        "old_id": old_id,
+                        "text": new_text,
+                        "new_id": new_id,
+                        "category": _result_category(fact),
+                    }
+                )
                 updated_count += 1
 
             elif act == "DELETE":
@@ -390,12 +410,25 @@ def execute_actions(
                         if not source_matches_prefixes(existing_source, allowed_prefixes):
                             raise PermissionError(f"old_id not authorized for delete: {old_id}")
                     engine.delete_memory(old_id)
-                    result_actions.append({"action": "delete", "old_id": old_id})
+                    result_actions.append(
+                        {
+                            "action": "delete",
+                            "old_id": old_id,
+                            "category": _result_category(fact),
+                        }
+                    )
                     deleted_count += 1
 
             elif act == "NOOP":
                 existing_id = action.get("existing_id")
-                result_actions.append({"action": "noop", "text": fact_text, "existing_id": existing_id})
+                result_actions.append(
+                    {
+                        "action": "noop",
+                        "text": fact_text,
+                        "existing_id": existing_id,
+                        "category": _result_category(fact),
+                    }
+                )
 
         except Exception as e:
             logger.error("Failed to execute %s for fact '%s': %s", act, fact_text[:50], e)

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -382,6 +382,14 @@ class TestExecuteActions:
 
         result = execute_actions(mock_engine, actions, facts, source="test/proj")
         assert result["stored_count"] == 1
+        assert result["actions"] == [
+            {
+                "action": "add",
+                "text": "New fact to store",
+                "id": 100,
+                "category": "DECISION",
+            }
+        ]
         mock_engine.add_memories.assert_called_once()
         # Verify API contract: sources must be a list, metadata includes category
         call_kwargs = mock_engine.add_memories.call_args
@@ -411,6 +419,15 @@ class TestExecuteActions:
 
         result = execute_actions(mock_engine, actions, facts, source="test/proj")
         assert result["updated_count"] == 1
+        assert result["actions"] == [
+            {
+                "action": "update",
+                "old_id": 42,
+                "text": "updated text",
+                "new_id": 101,
+                "category": "DECISION",
+            }
+        ]
         mock_engine.delete_memory.assert_called_once_with(42)
         # Verify metadata includes both category and supersedes
         call_kwargs = mock_engine.add_memories.call_args
@@ -426,6 +443,14 @@ class TestExecuteActions:
         result = execute_actions(mock_engine, actions, facts, source="test/proj")
         assert result["stored_count"] == 0
         assert result["updated_count"] == 0
+        assert result["actions"] == [
+            {
+                "action": "noop",
+                "text": "existing fact",
+                "existing_id": 30,
+                "category": "DETAIL",
+            }
+        ]
         mock_engine.add_memories.assert_not_called()
 
     def test_execute_delete(self):
@@ -437,6 +462,13 @@ class TestExecuteActions:
 
         result = execute_actions(mock_engine, actions, facts, source="test/proj")
         assert result["deleted_count"] == 1
+        assert result["actions"] == [
+            {
+                "action": "delete",
+                "old_id": 55,
+                "category": "DETAIL",
+            }
+        ]
         mock_engine.delete_memory.assert_called_once_with(55)
 
     def test_execute_with_out_of_bounds_fact_index(self):


### PR DESCRIPTION
## Summary
- include normalized category values in extraction result actions
- keep lowercase action names unchanged
- add execute_actions tests for add/update/noop/delete result payloads

## Testing
- uv run pytest -q tests/test_llm_extract.py tests/test_extract_api.py