### PR TITLE
fix: improve Claude natural memory recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,8 +857,8 @@ Memories supports automatic retrieval/extraction, with client-specific behavior:
 
 | Event | Hook | What happens |
 |-------|------|-------------|
-| Session start | `memory-recall.sh` | Loads project-specific memories into context |
-| Every prompt | `memory-query.sh` | Retrieves memories relevant to the question |
+| Session start | `memory-recall.sh` | Loads project-scoped memories into context and injects a short recall playbook for the session |
+| Every prompt | `memory-query.sh` | Retrieves memories relevant to the question using project-scoped search first, then falls back to broader search only if needed |
 | After response | `memory-extract.sh` | Extracts facts and stores via AUDN pipeline |
 | Before compaction | `memory-flush.sh` | Aggressive extraction before context loss |
 | Session end | `memory-commit.sh` | Final extraction pass |
@@ -901,6 +901,10 @@ Cursor is supported via manual MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.
 The installer writes runtime config to:
 - `~/.config/memories/env` for hook vars (`MEMORIES_URL`, optional `MEMORIES_API_KEY`, optional `MEMORIES_SOURCE_PREFIX` / `MEMORIES_SOURCE` for Codex notify source control)
 - repo `.env` for extraction vars (`EXTRACT_PROVIDER`, provider keys/URL)
+
+Claude/Cursor read hooks also support an optional `MEMORIES_SOURCE_PREFIXES` env var in
+`~/.config/memories/env`. It is a comma-separated list of source prefix templates and
+defaults to `claude-code/{project},learning/{project},wip/{project}`.
 
 **Target only Claude, Cursor, or Codex:**
 ```bash

--- a/integrations/QUICKSTART-LLM.md
+++ b/integrations/QUICKSTART-LLM.md
@@ -286,8 +286,8 @@ OpenClaw doesn't have hooks, so memory is agent-initiated via the skill. Update 
 
 | Hook | Event | Sync? | What It Does |
 |------|-------|-------|-------------|
-| `memory-recall.sh` | SessionStart | Sync | Searches Memories for project-specific memories, injects top 8 as context |
-| `memory-query.sh` | UserPromptSubmit | Sync | Searches Memories for memories relevant to the current prompt (skips short prompts) |
+| `memory-recall.sh` | SessionStart | Sync | Searches project-scoped memories, injects top results, and adds a short recall playbook for the session |
+| `memory-query.sh` | UserPromptSubmit | Sync | Searches project-scoped memories first and uses recent transcript context so short follow-up prompts still retrieve useful memories |
 | `memory-extract.sh` | Stop | Async | POSTs the last exchange to `/memory/extract` for fact extraction |
 | `memory-flush.sh` | PreCompact | Async | Same as extract but with `context=pre_compact` (more aggressive before context loss) |
 | `memory-commit.sh` | SessionEnd | Async | Final extraction pass when session ends |

--- a/integrations/claude-code/hooks/memory-query.sh
+++ b/integrations/claude-code/hooks/memory-query.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # memory-query.sh — UserPromptSubmit hook
 # Searches Memories for memories relevant to the current prompt.
+# Prefers project-scoped sources first and uses recent transcript context
+# so short follow-up prompts still retrieve the right memories.
 # Sync hook: blocks until done, injects additionalContext.
 
 set -euo pipefail
@@ -10,21 +12,153 @@ set -euo pipefail
 
 MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
 MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_SOURCE_PREFIXES="${MEMORIES_SOURCE_PREFIXES:-}"
+if [ -z "$MEMORIES_SOURCE_PREFIXES" ]; then
+  MEMORIES_SOURCE_PREFIXES='claude-code/{project},learning/{project},wip/{project}'
+fi
+MEMORIES_QUERY_SCOPED_K="${MEMORIES_QUERY_SCOPED_K:-3}"
+MEMORIES_QUERY_FALLBACK_K="${MEMORIES_QUERY_FALLBACK_K:-5}"
+MEMORIES_QUERY_SCOPED_THRESHOLD="${MEMORIES_QUERY_SCOPED_THRESHOLD:-0.35}"
+MEMORIES_QUERY_FALLBACK_THRESHOLD="${MEMORIES_QUERY_FALLBACK_THRESHOLD:-0.55}"
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // .workspace_roots[0] // .workspaceRoots[0] // empty')
+PROJECT=$(basename "${CWD:-}")
+if [ -z "$PROJECT" ] || [ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ]; then
+  PROJECT=""
+fi
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // .transcriptPath // empty')
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
-# Skip short/trivial prompts
-if [ ${#PROMPT} -lt 20 ]; then
+extract_recent_context() {
+  local transcript_path="$1"
+  if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
+    return 0
+  fi
+
+  tail -200 "$transcript_path" 2>/dev/null | jq -sr '
+    [
+      .[]
+      | select(.type == "user" or .type == "assistant")
+      | {
+          role: .type,
+          text: (
+            if .message.content | type == "string" then
+              .message.content
+            elif .message.content | type == "array" then
+              [.message.content[] | select(.type == "text") | .text] | join(" ")
+            else
+              ""
+            end
+          )
+        }
+      | select(.text != "" and (.text | length) > 4)
+    ]
+    | .[-4:]
+    | map(
+        (if .role == "user" then "User: " else "Assistant: " end) +
+        (
+          .text
+          | gsub("[\\r\\n]+"; " ")
+          | gsub("\\s+"; " ")
+          | .[0:500]
+        )
+      )
+    | join("\n")
+  ' 2>/dev/null || true
+}
+
+search_memories() {
+  local query="$1"
+  local prefix="${2:-}"
+  local limit="${3:-5}"
+  local threshold="${4:-0.4}"
+
+  local body
+  if [ -n "$prefix" ]; then
+    body=$(jq -nc \
+      --arg query "$query" \
+      --arg prefix "$prefix" \
+      --argjson k "$limit" \
+      --argjson threshold "$threshold" \
+      '{
+        query: $query,
+        source_prefix: $prefix,
+        k: $k,
+        hybrid: true,
+        threshold: $threshold
+      }')
+  else
+    body=$(jq -nc \
+      --arg query "$query" \
+      --argjson k "$limit" \
+      --argjson threshold "$threshold" \
+      '{
+        query: $query,
+        k: $k,
+        hybrid: true,
+        threshold: $threshold
+      }')
+  fi
+
+  curl -sf -X POST "$MEMORIES_URL/search" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $MEMORIES_API_KEY" \
+    -d "$body" \
+    2>/dev/null || true
+}
+
+CONTEXT=$(extract_recent_context "$TRANSCRIPT_PATH")
+QUERY_TEXT="$PROMPT"
+if [ -n "$CONTEXT" ]; then
+  if [ -n "$PROMPT" ]; then
+    QUERY_TEXT=$(printf 'Project: %s\nRecent conversation:\n%s\nCurrent prompt: %s' "${PROJECT:-unknown}" "$CONTEXT" "$PROMPT")
+  else
+    QUERY_TEXT=$(printf 'Project: %s\nRecent conversation:\n%s' "${PROJECT:-unknown}" "$CONTEXT")
+  fi
+fi
+
+# Skip only if we have neither a meaningful prompt nor recent conversation.
+if [ -z "$QUERY_TEXT" ] || { [ ${#PROMPT} -lt 20 ] && [ -z "$CONTEXT" ]; }; then
   exit 0
 fi
 
-RESULTS=$(curl -sf -X POST "$MEMORIES_URL/search" \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $MEMORIES_API_KEY" \
-  -d "{\"query\": $(echo "$PROMPT" | jq -Rs), \"k\": 5, \"hybrid\": true, \"threshold\": 0.4}" \
-  2>/dev/null \
-  | jq -r '[.results[]] | .[0:5] | map("- [\(.source)] \(.text)") | join("\n")' 2>/dev/null) || true
+RAW_RESPONSES=""
+if [ -n "$PROJECT" ]; then
+  IFS=',' read -r -a prefix_templates <<< "$MEMORIES_SOURCE_PREFIXES"
+  for raw_prefix in "${prefix_templates[@]}"; do
+    raw_prefix=$(echo "$raw_prefix" | xargs)
+    [ -z "$raw_prefix" ] && continue
+
+    prefix=$(printf '%s' "$raw_prefix" | sed "s/{project}/$PROJECT/g")
+    response=$(search_memories "$QUERY_TEXT" "$prefix" "$MEMORIES_QUERY_SCOPED_K" "$MEMORIES_QUERY_SCOPED_THRESHOLD")
+    if [ -n "$response" ]; then
+      RAW_RESPONSES=$(printf '%s\n%s' "$RAW_RESPONSES" "$response")
+    fi
+  done
+fi
+
+RESULTS_JSON=$(printf '%s\n' "$RAW_RESPONSES" | jq -sr '
+  map(select(type == "object") | (.results // []))
+  | add
+  | unique_by(.id)
+  | sort_by(-(.similarity // .rrf_score // 0))
+  | .[0:6]
+' 2>/dev/null) || RESULTS_JSON="[]"
+
+if [ "$RESULTS_JSON" = "[]" ]; then
+  FALLBACK_RESPONSE=$(search_memories "$QUERY_TEXT" "" "$MEMORIES_QUERY_FALLBACK_K" "$MEMORIES_QUERY_FALLBACK_THRESHOLD")
+  RESULTS_JSON=$(printf '%s' "$FALLBACK_RESPONSE" | jq -c '.results // []' 2>/dev/null) || RESULTS_JSON="[]"
+fi
+
+RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- [\(.source)] \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
 
 if [ -z "$RESULTS" ] || [ "$RESULTS" = "null" ]; then
   exit 0

--- a/integrations/claude-code/hooks/memory-recall.sh
+++ b/integrations/claude-code/hooks/memory-recall.sh
@@ -12,6 +12,12 @@ set -euo pipefail
 
 MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
 MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_SOURCE_PREFIXES="${MEMORIES_SOURCE_PREFIXES:-}"
+if [ -z "$MEMORIES_SOURCE_PREFIXES" ]; then
+  MEMORIES_SOURCE_PREFIXES='claude-code/{project},learning/{project},wip/{project}'
+fi
+MEMORIES_RECALL_SCOPED_THRESHOLD="${MEMORIES_RECALL_SCOPED_THRESHOLD:-0.35}"
+MEMORIES_RECALL_FALLBACK_THRESHOLD="${MEMORIES_RECALL_FALLBACK_THRESHOLD:-0.55}"
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // .workspace_roots[0] // empty')
@@ -20,26 +26,124 @@ if [ -z "$CWD" ]; then
 fi
 
 PROJECT=$(basename "$CWD")
-
-BODY=$(jq -nc --arg q "project $PROJECT conventions decisions patterns" '{"query": $q, "k": 10, "hybrid": true}')
-
-# Get raw search results
-RAW_RESULTS=$(curl -sf -X POST "$MEMORIES_URL/search" \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $MEMORIES_API_KEY" \
-  -d "$BODY" \
-  2>/dev/null) || true
-
-if [ -z "$RAW_RESULTS" ] || [ "$RAW_RESULTS" = "null" ]; then
+if [ -z "$PROJECT" ] || [ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ]; then
   exit 0
 fi
 
-# Format for context injection
-CONTEXT_RESULTS=$(echo "$RAW_RESULTS" | jq -r '[.results[]] | .[0:8] | map("- \(.text)") | join("\n")' 2>/dev/null) || true
+search_memories() {
+  local query="$1"
+  local prefix="${2:-}"
+  local limit="${3:-5}"
+  local threshold="${4:-0.4}"
 
-if [ -z "$CONTEXT_RESULTS" ] || [ "$CONTEXT_RESULTS" = "null" ]; then
-  exit 0
+  local body
+  if [ -n "$prefix" ]; then
+    body=$(jq -nc \
+      --arg query "$query" \
+      --arg prefix "$prefix" \
+      --argjson k "$limit" \
+      --argjson threshold "$threshold" \
+      '{
+        query: $query,
+        source_prefix: $prefix,
+        k: $k,
+        hybrid: true,
+        threshold: $threshold
+      }')
+  else
+    body=$(jq -nc \
+      --arg query "$query" \
+      --argjson k "$limit" \
+      --argjson threshold "$threshold" \
+      '{
+        query: $query,
+        k: $k,
+        hybrid: true,
+        threshold: $threshold
+      }')
+  fi
+
+  curl -sf -X POST "$MEMORIES_URL/search" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: $MEMORIES_API_KEY" \
+    -d "$body" \
+    2>/dev/null || true
+}
+
+query_for_prefix() {
+  local prefix="$1"
+  case "$prefix" in
+    claude-code/*)
+      printf 'project %s architecture decisions conventions patterns' "$PROJECT"
+      ;;
+    learning/*)
+      printf 'project %s fixes gotchas learnings workarounds' "$PROJECT"
+      ;;
+    wip/*)
+      printf 'project %s deferred work blockers open threads revisit later' "$PROJECT"
+      ;;
+    *)
+      printf 'project %s conventions decisions patterns' "$PROJECT"
+      ;;
+  esac
+}
+
+RAW_RESPONSES=""
+SCOPED_PREFIX_LIST=""
+IFS=',' read -r -a prefix_templates <<< "$MEMORIES_SOURCE_PREFIXES"
+for raw_prefix in "${prefix_templates[@]}"; do
+  raw_prefix=$(echo "$raw_prefix" | xargs)
+  [ -z "$raw_prefix" ] && continue
+
+  prefix=$(printf '%s' "$raw_prefix" | sed "s/{project}/$PROJECT/g")
+  query=$(query_for_prefix "$prefix")
+  limit=3
+  case "$prefix" in
+    claude-code/*) limit=4 ;;
+    learning/*|wip/*) limit=2 ;;
+  esac
+
+  response=$(search_memories "$query" "$prefix" "$limit" "$MEMORIES_RECALL_SCOPED_THRESHOLD")
+  if [ -n "$response" ]; then
+    RAW_RESPONSES=$(printf '%s\n%s' "$RAW_RESPONSES" "$response")
+  fi
+
+  if [ -n "$SCOPED_PREFIX_LIST" ]; then
+    SCOPED_PREFIX_LIST="$SCOPED_PREFIX_LIST, "
+  fi
+  SCOPED_PREFIX_LIST="$SCOPED_PREFIX_LIST$prefix"
+done
+
+RESULTS_JSON=$(printf '%s\n' "$RAW_RESPONSES" | jq -sr '
+  map(select(type == "object") | (.results // []))
+  | add
+  | unique_by(.id)
+  | sort_by(-(.similarity // .rrf_score // 0))
+  | .[0:8]
+' 2>/dev/null) || RESULTS_JSON="[]"
+
+if [ "$RESULTS_JSON" = "[]" ]; then
+  FALLBACK_RESPONSE=$(search_memories "project $PROJECT conventions decisions patterns" "" 6 "$MEMORIES_RECALL_FALLBACK_THRESHOLD")
+  RESULTS_JSON=$(printf '%s' "$FALLBACK_RESPONSE" | jq -c '.results // []' 2>/dev/null) || RESULTS_JSON="[]"
 fi
+
+CONTEXT_RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- [\(.source)] \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
+
+PLAYBOOK=$(cat <<EOF
+## Memory Playbook
+
+- Treat hook-injected memories as a starting point, not the full search space.
+- Before answering questions about prior decisions, deferred work, architecture, or conventions, run project-scoped \`memory_search\` first.
+- Prefer these scoped prefixes before broader searches: $SCOPED_PREFIX_LIST.
+- For short follow-up prompts, include recent conversation context in the query instead of searching with the raw prompt alone.
+EOF
+)
 
 # --- Hydrate auto-memory MEMORY.md ---
 # Claude Code's auto-memory loads MEMORY.md into every conversation (first 200 lines).
@@ -53,7 +157,13 @@ MEMORY_FILE="$MEMORY_DIR/MEMORY.md"
 # Create memory dir if it doesn't exist (enables auto-memory for all projects)
 mkdir -p "$MEMORY_DIR" 2>/dev/null || true
 
-MEMORY_RESULTS=$(echo "$RAW_RESULTS" | jq -r '[.results[]] | .[0:8] | map("- \(.text)") | join("\n")' 2>/dev/null) || true
+MEMORY_RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
 
 if [ -n "$MEMORY_RESULTS" ] && [ "$MEMORY_RESULTS" != "null" ]; then
   MANUAL_SECTION=""
@@ -80,9 +190,12 @@ if [ -n "$MEMORY_RESULTS" ] && [ "$MEMORY_RESULTS" != "null" ]; then
 fi
 
 # --- Output context for Claude Code ---
-jq -n --arg memories "$CONTEXT_RESULTS" '{
+jq -n --arg memories "$CONTEXT_RESULTS" --arg playbook "$PLAYBOOK" '{
   hookSpecificOutput: {
     hookEventName: "SessionStart",
-    additionalContext: ("## Relevant Memories\n\n" + $memories)
+    additionalContext: (
+      (if ($memories | length) > 0 then "## Relevant Memories\n\n" + $memories + "\n\n" else "" end) +
+      $playbook
+    )
   }
 }'

--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -36,6 +36,9 @@ don't come with that cue.
   they don't reference a past session. "Add webhook support to the notifications service"
   should trigger a search for any stored context about notifications, webhooks, or
   related deferred work.
+- When the user's message is a short follow-up that depends on recent context ("what
+  about retries?", "does that still apply?", "should we keep it?"). Passive hook recall
+  is often too generic here — run an explicit search using the recent conversation topic.
 - Before asking a clarifying question about project architecture or preferences
 - When picking up work in a domain where deferred tasks might exist
 - Before attempting something that feels like it might have failed before
@@ -44,11 +47,16 @@ don't come with that cue.
 
 **How to search:**
 - Use `memory_search` with natural language queries
+- Search project-scoped prefixes first when you know the project. Prefer
+  `claude-code/{project}`, `learning/{project}`, and `wip/{project}` before broad global
+  searches so unrelated projects do not drown out local signal.
 - Try 2-3 query angles if the first search doesn't find what you need
 - Search for deferred work: `"deferred TODO revisit later wip {project}"`
 - Search for past failures: `"failure fix gotcha {technology}"`
 - Search for decisions: `"decision chose selected approach {topic}"`
 - Search by domain: `"{project} {feature-area} architecture design"`
+- For short follow-ups, include recent conversation context in the query instead of
+  searching with only the latest user message.
 
 **What to do with results:**
 - Surface relevant findings to the user before proposing solutions. If you find that
@@ -209,6 +217,9 @@ For simple cases (2 clear, novel facts), individual `memory_add` calls are fine.
 
 - **Auto-memory** handles project conventions and patterns in local files — let it do its job
 - **Session hooks** provide baseline context at startup — don't duplicate that work
+- **Hook-injected recall is a starting point, not a substitute for active recall.** If the
+  retrieved memories look noisy, low-confidence, or obviously cross-project, run explicit
+  `memory_search` calls yourself before answering.
 - **Extraction hooks** (Stop, PreCompact, SessionEnd) already trigger `memory_extract`
   via HTTP at lifecycle boundaries. The skill triggers extraction *within* a session at
   natural breakpoints that hooks miss — like mid-conversation decision changes or

--- a/tests/test_claude_memory_hooks.py
+++ b/tests/test_claude_memory_hooks.py
@@ -1,0 +1,293 @@
+"""Tests for Claude memory read hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+HOOKS_DIR = Path(__file__).resolve().parents[1] / "integrations" / "claude-code" / "hooks"
+QUERY_SCRIPT = HOOKS_DIR / "memory-query.sh"
+RECALL_SCRIPT = HOOKS_DIR / "memory-recall.sh"
+
+
+def _write_fake_curl(bin_dir: Path) -> Path:
+    script = bin_dir / "curl"
+    script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FAKE_CURL_CALLS:?}"
+: "${FAKE_CURL_RESPONSES:?}"
+
+url=""
+body=""
+pending_data=0
+
+for arg in "$@"; do
+  if [ "$pending_data" -eq 1 ]; then
+    body="$arg"
+    pending_data=0
+    continue
+  fi
+
+  case "$arg" in
+    -d|--data|--data-raw|--data-binary)
+      pending_data=1
+      ;;
+    http://*|https://*)
+      url="$arg"
+      ;;
+  esac
+done
+
+jq -nc --arg url "$url" --argjson body "$body" '{url: $url, body: $body}' >> "$FAKE_CURL_CALLS"
+
+jq -c --arg url "$url" --argjson body "$body" '
+  ([
+    .[]
+    | . as $rule
+    | select(($rule.url_suffix == null) or ($url | endswith($rule.url_suffix)))
+    | select(($rule.source_prefix // "") == (($body.source_prefix // "")))
+    | select(
+        ($rule.query_contains // null) == null
+        or (($body.query // "") | contains($rule.query_contains))
+      )
+    | $rule.response
+  ][0]) // {"results": [], "count": 0}
+' "$FAKE_CURL_RESPONSES"
+"""
+    )
+    script.chmod(0o755)
+    return script
+
+
+def _run_hook(
+    script: Path,
+    tmp_path: Path,
+    payload: dict[str, object],
+    responses: list[dict[str, object]],
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[dict[str, object]], Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    calls_file = tmp_path / "curl-calls.jsonl"
+    responses_file = tmp_path / "curl-responses.json"
+    responses_file.write_text(json.dumps(responses))
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "MEMORIES_URL": "http://127.0.0.1:9999",
+            "MEMORIES_API_KEY": "test-key",
+            "MEMORIES_ENV_FILE": str(tmp_path / "missing-env"),
+            "FAKE_CURL_CALLS": str(calls_file),
+            "FAKE_CURL_RESPONSES": str(responses_file),
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+
+    result = subprocess.run(
+        [str(script)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    calls: list[dict[str, object]] = []
+    if calls_file.exists():
+        calls = [json.loads(line) for line in calls_file.read_text().splitlines() if line.strip()]
+
+    return result, calls, home_dir
+
+
+def test_memory_query_uses_transcript_context_for_short_followups(tmp_path: Path) -> None:
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {"content": "Let's design notifications for the billing service."},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": "We should revisit rate limiting before locking the webhook shape."},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "wip/memories",
+            "query_contains": "notifications",
+            "response": {
+                "results": [
+                    {
+                        "id": 11,
+                        "source": "wip/memories",
+                        "text": "Notification design is deferred until rate limiting is settled.",
+                        "similarity": 0.86,
+                    }
+                ],
+                "count": 1,
+            },
+        },
+        {
+            "url_suffix": "/search",
+            "source_prefix": "",
+            "response": {
+                "results": [
+                    {
+                        "id": 99,
+                        "source": "other/project",
+                        "text": "Unrelated global memory that should not appear.",
+                        "similarity": 0.9,
+                    }
+                ],
+                "count": 1,
+            },
+        },
+    ]
+
+    payload = {
+        "cwd": "/Users/example/memories",
+        "prompt": "what about retries?",
+        "transcript_path": str(transcript),
+    }
+
+    result, calls, _ = _run_hook(QUERY_SCRIPT, tmp_path, payload, responses)
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    ctx = output["hookSpecificOutput"]["additionalContext"]
+    assert "Notification design is deferred until rate limiting is settled." in ctx
+    assert "Unrelated global memory" not in ctx
+    assert all(call["body"].get("source_prefix", "") != "" for call in calls)
+    assert any("notifications" in call["body"]["query"] for call in calls)
+
+
+def test_memory_query_falls_back_to_global_search_when_scoped_is_empty(tmp_path: Path) -> None:
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "",
+            "query_contains": "redis connection failure workaround",
+            "response": {
+                "results": [
+                    {
+                        "id": 21,
+                        "source": "infra/shared",
+                        "text": "Redis connection issues were fixed by setting REDIS_URL explicitly.",
+                        "similarity": 0.8,
+                    }
+                ],
+                "count": 1,
+            },
+        }
+    ]
+
+    payload = {
+        "cwd": "/Users/example/memories",
+        "prompt": "look up the redis connection failure workaround",
+    }
+
+    result, calls, _ = _run_hook(QUERY_SCRIPT, tmp_path, payload, responses)
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    ctx = output["hookSpecificOutput"]["additionalContext"]
+    assert "Redis connection issues were fixed by setting REDIS_URL explicitly." in ctx
+    assert any(call["body"].get("source_prefix", "") == "" for call in calls)
+
+
+def test_memory_recall_scopes_results_and_writes_memory_file(tmp_path: Path) -> None:
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "claude-code/memories",
+            "response": {
+                "results": [
+                    {
+                        "id": 1,
+                        "source": "claude-code/memories",
+                        "text": "Claude read hooks should search project-scoped memories before broad global search.",
+                        "similarity": 0.92,
+                    }
+                ],
+                "count": 1,
+            },
+        },
+        {
+            "url_suffix": "/search",
+            "source_prefix": "learning/memories",
+            "response": {
+                "results": [
+                    {
+                        "id": 2,
+                        "source": "learning/memories",
+                        "text": "Short follow-up prompts need transcript context to retrieve the right memories.",
+                        "similarity": 0.88,
+                    }
+                ],
+                "count": 1,
+            },
+        },
+        {
+            "url_suffix": "/search",
+            "source_prefix": "wip/memories",
+            "response": {
+                "results": [
+                    {
+                        "id": 3,
+                        "source": "wip/memories",
+                        "text": "Deferred: tighten Claude session-start recall before broader automation work.",
+                        "similarity": 0.84,
+                    }
+                ],
+                "count": 1,
+            },
+        },
+    ]
+
+    payload = {"cwd": "/Users/example/memories"}
+
+    result, calls, home_dir = _run_hook(RECALL_SCRIPT, tmp_path, payload, responses)
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    ctx = output["hookSpecificOutput"]["additionalContext"]
+    assert "## Relevant Memories" in ctx
+    assert "## Memory Playbook" in ctx
+    assert "claude-code/memories" in ctx
+    assert "learning/memories" in ctx
+    assert "wip/memories" in ctx
+
+    memory_file = home_dir / ".claude" / "projects" / "-Users-example-memories" / "memory" / "MEMORY.md"
+    assert memory_file.exists()
+    memory_text = memory_file.read_text()
+    assert "## Synced from Memories" in memory_text
+    assert "Claude read hooks should search project-scoped memories" in memory_text
+    assert "## Memory Playbook" not in memory_text
+
+    prefixes = [call["body"].get("source_prefix", "") for call in calls]
+    assert prefixes == ["claude-code/memories", "learning/memories", "wip/memories"]


### PR DESCRIPTION
## Summary
- make Claude read hooks search project-scoped prefixes before falling back to global search
- use recent transcript context for UserPromptSubmit so short follow-up prompts still retrieve the right memories
- inject a short session-start recall playbook and add hook coverage tests for the new behavior

## Testing
- uv run pytest tests/test_claude_memory_hooks.py tests/test_codex_notify_hook.py tests/test_installer.py tests/test_extract_api.py