### PR TITLE
fix: reduce Claude meta phrasing in memory followups

### DIFF
--- a/integrations/claude-code/hooks/memory-query.sh
+++ b/integrations/claude-code/hooks/memory-query.sh
@@ -44,7 +44,32 @@ build_response_hint() {
 - The user is resuming an existing decision or constraint.
 - Start by restating the remembered choice or boundary in concrete terms before asking what to do next.
 - Keep the concrete implementation choice and the boundary condition together in the same sentence.
+- Do not answer with meta phrases like `stored decision` or `memory confirms`.
 $(if [ -n "$primary_example" ]; then printf -- "- Suggested first sentence: %s\n" "$primary_example"; elif [ -n "$primary_memory" ]; then printf -- "- Most relevant context to restate: %s\n" "$primary_memory"; fi)
+EOF
+      ;;
+    *"should we switch to "*|*"should i switch to "*)
+      cat <<EOF
+## Follow-up Response Hint
+
+- This is a switch-now follow-up.
+- Answer yes or no in the first sentence instead of asking the user to reconfirm the need.
+- If the remembered decision keeps the current implementation until a condition changes, say `not yet` and restate both the current choice and the trigger.
+- Do not answer with meta phrases like `the stored decision was`.
+- Keep qualifiers like `until`, `unless`, `because`, or `blocked on` if they appear in the retrieved memory.
+$(if [ -n "$primary_example" ]; then printf -- "- If the memory already answers the question, use this answer shape: Not yet — %s\n" "$primary_example"; elif [ -n "$primary_memory" ]; then printf -- "- Most relevant decision to preserve: %s\n" "$primary_memory"; fi)
+EOF
+      ;;
+    *"okay for now"*)
+      cat <<EOF
+## Follow-up Response Hint
+
+- This is a simple-for-now follow-up.
+- Answer directly in the first sentence instead of asking the user to reconfirm the decision.
+- Reuse the current choice together with the condition that would force a more complex design later.
+- Do not answer with meta phrases like `the stored decision is` or `memory confirms`.
+- Keep qualifiers like `until`, `unless`, `because`, or `blocked on` if they appear in the retrieved memory.
+$(if [ -n "$primary_example" ]; then printf -- "- If the memory already answers the question, use this answer shape: Yes — %s\n" "$primary_example"; elif [ -n "$primary_memory" ]; then printf -- "- Most relevant decision to preserve: %s\n" "$primary_memory"; fi)
 EOF
       ;;
     *"does that still apply"*|*"should we keep it"*|*"can we keep it simple"*)

--- a/tests/test_claude_memory_hooks.py
+++ b/tests/test_claude_memory_hooks.py
@@ -292,7 +292,82 @@ def test_memory_query_adds_continuation_hint_for_resume_prompts(tmp_path: Path) 
     ctx = output["hookSpecificOutput"]["additionalContext"]
     assert "## Context Continuation Hint" in ctx
     assert "restating the remembered choice" in ctx
+    assert "Do not answer with meta phrases" in ctx
     assert "Suggested first sentence: SQLite is preferred over Redis for the local cache in single-node deployments." in ctx
+
+
+def test_memory_query_adds_switch_now_hint_for_change_prompts(tmp_path: Path) -> None:
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "claude-code/memories",
+            "query_contains": "should we switch to Redis now?",
+            "response": {
+                "results": [
+                    {
+                        "id": 51,
+                        "source": "claude-code/memories",
+                        "text": "memories decision: keep the build cache manifest in SQLite until multiple workers need shared invalidation.",
+                        "similarity": 0.91,
+                    }
+                ],
+                "count": 1,
+            },
+        }
+    ]
+
+    payload = {
+        "cwd": "/Users/example/memories",
+        "prompt": "should we switch to Redis now?",
+    }
+
+    result, _, _ = _run_hook(QUERY_SCRIPT, tmp_path, payload, responses)
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    ctx = output["hookSpecificOutput"]["additionalContext"]
+    assert "## Follow-up Response Hint" in ctx
+    assert "switch-now follow-up" in ctx
+    assert "Answer yes or no in the first sentence" in ctx
+    assert "Do not answer with meta phrases" in ctx
+    assert "use this answer shape: Not yet — keep the build cache manifest in SQLite until multiple workers need shared invalidation." in ctx
+
+
+def test_memory_query_adds_for_now_hint_for_simple_followups(tmp_path: Path) -> None:
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "claude-code/memories",
+            "query_contains": "is file-based storage okay for now?",
+            "response": {
+                "results": [
+                    {
+                        "id": 61,
+                        "source": "claude-code/memories",
+                        "text": "memories decision: keep field-note drafts in local Markdown files until cross-device sync is required.",
+                        "similarity": 0.9,
+                    }
+                ],
+                "count": 1,
+            },
+        }
+    ]
+
+    payload = {
+        "cwd": "/Users/example/memories",
+        "prompt": "is file-based storage okay for now?",
+    }
+
+    result, _, _ = _run_hook(QUERY_SCRIPT, tmp_path, payload, responses)
+
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    ctx = output["hookSpecificOutput"]["additionalContext"]
+    assert "## Follow-up Response Hint" in ctx
+    assert "simple-for-now follow-up" in ctx
+    assert "Answer directly in the first sentence" in ctx
+    assert "Do not answer with meta phrases" in ctx
+    assert "use this answer shape: Yes — keep field-note drafts in local Markdown files until cross-device sync is required." in ctx
 
 
 def test_memory_recall_scopes_results_and_writes_memory_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This follow-up to #19 tightens Claude's answer shaping for natural memory follow-ups.

The previous hook work improved retrieval and short follow-up recall, but the widened live benchmark still exposed a narrower failure mode: Claude sometimes retrieved the correct memory and then answered with meta phrasing like `the stored decision is...` instead of directly answering the user's question.

## Problem

Under broader natural follow-up prompts, Claude still leaked memory-process language even when recall was correct. The main misses were:
- `should we switch to Redis now?` answering with meta setup before the actual answer
- `is file-based storage okay for now?` using `stored decision` phrasing instead of just confirming the current choice
- continuity prompts occasionally restating context in a way that sounded like memory narration instead of direct assistance

## Changes

### `integrations/claude-code/hooks/memory-query.sh`
- Adds anti-meta guidance to continuation prompts so Claude avoids phrases like `stored decision` or `memory confirms`
- Adds a dedicated `switch now` follow-up hint path for prompts like `should we switch to ... now?`
- Adds a dedicated `okay for now` follow-up hint path for prompts like `is file-based storage okay for now?`
- Keeps the answer-shape examples tied to the top recalled memory so Claude answers directly in the first sentence with the remembered choice and its boundary condition

### `tests/test_claude_memory_hooks.py`
- Covers the new anti-meta continuation hint
- Covers the `switch now` hint path
- Covers the `okay for now` hint path

## Validation

### Unit tests
```bash
uv run pytest tests/test_claude_memory_hooks.py
```

### Live staged-Claude benchmark
Validated against the widened Optima conversation-checkpoint suite on the isolated Memories test instance at `localhost:8901`.

Key outcome:
- widened live suite moved from interim failing runs (`0.875` and `0.8375`) to `1.0`

The new cases that motivated this PR were natural variants of the earlier benchmark:
- `relaypad-followup`: `should we switch to Redis now?`
- `seabook-followup`: `is file-based storage okay for now?`

## Notes

This PR only changes the Claude-side hook behavior. It does not modify the Memories server runtime, retrieval engine, embedder, or production service configuration.
