### PR TITLE
docs: add quick operating rules to memories skill

### DIFF
--- a/skills/memories/SKILL.md
+++ b/skills/memories/SKILL.md
@@ -23,6 +23,20 @@ passively) and lifecycle hooks (which provide baseline context at startup).
 Your job is the judgment layer: deciding what's worth storing, when to store it, when
 to actively search for context, and when to trigger lifecycle operations.
 
+## Quick Operating Rules
+
+- Search before asking architecture, resumption, or preference questions.
+- If recalled context already answers the question, answer in sentence one.
+- Do not narrate the memory process. Avoid phrases like `stored decision`, `memory confirms`, or `I found`.
+- For short follow-ups, restate the current choice and the trigger together.
+- If work is deferred or blocked, say `not yet`, `deferred`, or `blocked on` directly.
+- Preserve boundary words like `until`, `unless`, and `because`.
+
+Examples:
+- `Does that still apply?` -> `Yes — SQLite is still the local cache until shared invalidation is required.`
+- `Should we switch now?` -> `Not yet — stay on the current approach until the trigger changes.`
+- `Is file-based storage okay for now?` -> `Yes — keep the simple local format until cross-device sync is required.`
+
 ## Three Responsibilities
 
 ### 1. Read — Proactive Recall


### PR DESCRIPTION
## Summary

This updates the `memories` skill with a compact `Quick Operating Rules` block near the top of `SKILL.md`.

The goal is to make Claude follow the most important read-path behaviors more consistently in ordinary conversation without rewriting the rest of the skill:
- search before asking architecture / resumption / preference questions
- answer directly when recalled context already answers the question
- avoid meta phrasing like `stored decision` / `memory confirms`
- keep the current choice and its trigger together on short follow-ups
- say `not yet` / `deferred` / `blocked on` directly for deferred work

## Why

The hook work is already strong, but repeated Optima runs showed the skill still had leverage on high-variance natural follow-ups.

The best-performing staged-only skill variant was not a full rewrite. It was a small top-of-file operating-rules block plus compact examples for:
- `Does that still apply?`
- `Should we switch now?`
- `Is file-based storage okay for now?`

## Change

### `skills/memories/SKILL.md`
- adds `## Quick Operating Rules` near the top of the skill
- adds three compact example answer shapes for common natural follow-ups
- leaves the existing search / write / lifecycle guidance intact

## Validation

### Hard-case repeated screen
Using the Optima conversation checkpoint benchmark with staged Claude homes against isolated Memories on `localhost:8901`:
- baseline skill: `0.775` over 8 repeated trials on the two unstable follow-up cases
- quick-rules-examples variant: `0.9625` over the same 8 repeated trials

The unstable cases were:
- `lc-cachelane-followup`
- `lc-relaypad-followup`

### Repo-state full-suite validation
After applying the quick-rules block to the actual repo `SKILL.md`, a staged repeated full-suite check scored:
- `0.925` over 3 repeated trials

This is not a perfect `1.0`, so live variance still exists, but it is strong enough to keep the skill change.

## Notes

- This PR changes only the skill text
- It does not modify hook code or the Memories server runtime
- All validation was staged against `8901`, not production `8900`
