### PR TITLE
feat: extend Python client SDK

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -93,6 +93,40 @@ class MemoriesClient:
     def conflicts(self):
         return self._request("GET", "/memory/conflicts")
 
+    # --- Links ---
+
+    def add_link(self, from_id: int, to_id: int, link_type: str = "related_to"):
+        return self._request("POST", f"/memory/{from_id}/link",
+                             json={"to_id": to_id, "type": link_type})
+
+    def get_links(self, memory_id: int, link_type: str | None = None,
+                  include_incoming: bool = False):
+        params: dict = {"include_incoming": include_incoming}
+        if link_type:
+            params["type"] = link_type
+        return self._request("GET", f"/memory/{memory_id}/links", params=params)
+
+    def remove_link(self, from_id: int, to_id: int, link_type: str = "related_to"):
+        return self._request("DELETE", f"/memory/{from_id}/link/{to_id}",
+                             params={"type": link_type})
+
+    # --- Events ---
+
+    def recent_events(self, limit: int = 50):
+        return self._request("GET", "/events/recent", params={"limit": limit})
+
+    def register_webhook(self, url: str, events: list[str] | None = None):
+        body: dict = {"url": url}
+        if events:
+            body["events"] = events
+        return self._request("POST", "/webhooks", json=body)
+
+    def list_webhooks(self):
+        return self._request("GET", "/webhooks")
+
+    def delete_webhook(self, webhook_id: str):
+        return self._request("DELETE", f"/webhooks/{webhook_id}")
+
     # --- Memory CRUD ---
 
     def add(self, text: str, source: str = "cli",
@@ -201,6 +235,12 @@ class MemoriesClient:
 
     def reload_embedder(self):
         return self._request("POST", "/maintenance/embedder/reload")
+
+    def reembed(self, model: str | None = None):
+        body: dict = {}
+        if model:
+            body["model"] = model
+        return self._request("POST", "/maintenance/reembed", json=body)
 
     # --- Backup ---
 

--- a/memories_client.py
+++ b/memories_client.py
@@ -1,0 +1,27 @@
+"""Memories Python Client SDK.
+
+Standalone HTTP client for the Memories API. Can be used independently
+of the CLI — just import and use:
+
+    from memories_client import MemoriesClient
+
+    client = MemoriesClient("http://localhost:8900", api_key="your-key")
+    results = client.search("what did we decide about auth?")
+    client.add("We chose JWT tokens for auth", source="claude-code/myapp")
+"""
+
+from cli.client import (
+    MemoriesClient,
+    CliConnectionError as ConnectionError,
+    CliAuthError as AuthError,
+    CliNotFoundError as NotFoundError,
+    CliServerError as ServerError,
+)
+
+__all__ = [
+    "MemoriesClient",
+    "ConnectionError",
+    "AuthError",
+    "NotFoundError",
+    "ServerError",
+]

--- a/tests/test_client_sdk.py
+++ b/tests/test_client_sdk.py
@@ -1,0 +1,102 @@
+"""Tests for the Memories Python Client SDK — new endpoint coverage."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cli.client import MemoriesClient
+
+
+class FakeTransport:
+    """Mock httpx transport that records requests and returns canned responses."""
+
+    def __init__(self):
+        self.calls = []
+        self._responses = {}
+
+    def set_response(self, method: str, path: str, json_data: dict, status: int = 200):
+        self._responses[(method.upper(), path)] = (status, json_data)
+
+    def handle_request(self, request):
+        import httpx
+        key = (request.method, request.url.raw_path.decode().split("?")[0])
+        status, data = self._responses.get(key, (200, {}))
+        self.calls.append({"method": request.method, "path": key[1], "content": request.content})
+        import json
+        return httpx.Response(status, json=data)
+
+
+@pytest.fixture
+def client():
+    transport = FakeTransport()
+    c = MemoriesClient("http://localhost:8900", transport=transport)
+    c._transport = transport
+    return c, transport
+
+
+class TestLinkMethods:
+    def test_add_link(self, client):
+        c, t = client
+        t.set_response("POST", "/memory/1/link", {"from_id": 1, "to_id": 2, "type": "related_to"})
+        result = c.add_link(from_id=1, to_id=2, link_type="related_to")
+        assert result["from_id"] == 1
+
+    def test_get_links(self, client):
+        c, t = client
+        t.set_response("GET", "/memory/1/links", {"memory_id": 1, "links": []})
+        result = c.get_links(memory_id=1)
+        assert result["links"] == []
+
+    def test_remove_link(self, client):
+        c, t = client
+        t.set_response("DELETE", "/memory/1/link/2", {"removed": True})
+        result = c.remove_link(from_id=1, to_id=2)
+        assert result["removed"] is True
+
+
+class TestEventMethods:
+    def test_recent_events(self, client):
+        c, t = client
+        t.set_response("GET", "/events/recent", {"events": [], "count": 0})
+        result = c.recent_events()
+        assert result["count"] == 0
+
+    def test_register_webhook(self, client):
+        c, t = client
+        t.set_response("POST", "/webhooks", {"id": "1", "url": "http://test.com"})
+        result = c.register_webhook("http://test.com")
+        assert result["url"] == "http://test.com"
+
+    def test_list_webhooks(self, client):
+        c, t = client
+        t.set_response("GET", "/webhooks", {"webhooks": []})
+        result = c.list_webhooks()
+        assert result["webhooks"] == []
+
+    def test_delete_webhook(self, client):
+        c, t = client
+        t.set_response("DELETE", "/webhooks/1", {"deleted": True})
+        result = c.delete_webhook("1")
+        assert result["deleted"] is True
+
+
+class TestMaintenanceMethods:
+    def test_reembed(self, client):
+        c, t = client
+        t.set_response("POST", "/maintenance/reembed", {"status": "completed"})
+        result = c.reembed(model="new-model")
+        assert result["status"] == "completed"
+
+    def test_reembed_no_model(self, client):
+        c, t = client
+        t.set_response("POST", "/maintenance/reembed", {"status": "completed"})
+        result = c.reembed()
+        assert result["status"] == "completed"
+
+
+class TestTopLevelImport:
+    def test_import_from_memories_client(self):
+        from memories_client import MemoriesClient, ConnectionError, AuthError
+        assert MemoriesClient is not None
+        assert ConnectionError is not None
+        assert AuthError is not None


### PR DESCRIPTION
## Summary
- Add missing client methods for links, events/webhooks, and reembed endpoints
- Create `memories_client.py` as top-level SDK re-export: `from memories_client import MemoriesClient`
- Cleaner error names for standalone usage: `ConnectionError`, `AuthError`, `NotFoundError`, `ServerError`
- No duplication — extends existing `cli/client.py` and re-exports

## Test plan
- [x] 10 new tests: links CRUD, events/webhooks, reembed, top-level import
- [x] Full suite: 589 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)