### PR TITLE
feat: search quality feedback loop

### DIFF
--- a/app.py
+++ b/app.py
@@ -1371,6 +1371,36 @@ async def usage(
     return usage_tracker.get_usage(period)
 
 
+class SearchFeedbackRequest(BaseModel):
+    memory_id: int = Field(..., description="Memory ID the feedback applies to")
+    query: str = Field("", description="The search query that produced this result")
+    signal: str = Field(..., pattern="^(useful|not_useful)$", description="Relevance signal")
+    search_id: str = Field("", description="Optional ID grouping results from the same search")
+
+
+@app.post("/search/feedback")
+async def search_feedback(request_body: SearchFeedbackRequest, request: Request):
+    """Record explicit relevance feedback for a search result."""
+    _get_auth(request)
+    usage_tracker.log_search_feedback(
+        memory_id=request_body.memory_id,
+        query=request_body.query,
+        signal=request_body.signal,
+        search_id=request_body.search_id,
+    )
+    return {"status": "recorded"}
+
+
+@app.get("/metrics/search-quality")
+async def search_quality_metrics(
+    request: Request,
+    period: str = Query("7d", pattern="^(today|7d|30d|all)$"),
+):
+    """Aggregated search quality metrics — rank distribution, feedback ratios, volume."""
+    _get_auth(request)
+    return usage_tracker.get_search_quality(period)
+
+
 @app.post("/maintenance/embedder/reload")
 async def reload_embedder(request: Request):
     """Reload in-process embedder runtime and release old inference objects."""
@@ -1544,15 +1574,18 @@ async def search(request_body: SearchRequest, request: Request):
                 source_prefix=request_body.source_prefix,
             )
         results = auth.filter_results(results)
+        result_count = len(results)
         usage_tracker.log_api_event("search", request_body.source)
-        for r in results:
+        for rank, r in enumerate(results, 1):
             if "id" in r:
                 usage_tracker.log_retrieval(
                     memory_id=r["id"],
                     query=request_body.query[:200],
                     source=request_body.source,
+                    rank=rank,
+                    result_count=result_count,
                 )
-        return {"query": request_body.query, "results": results, "count": len(results)}
+        return {"query": request_body.query, "results": results, "count": result_count}
     except Exception as e:
         logger.exception("Search failed")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -1583,14 +1616,17 @@ async def search_batch(request_body: SearchBatchRequest, request: Request):
                     source_prefix=item.source_prefix,
                 )
             results = auth.filter_results(results)
-            for r in results:
+            batch_result_count = len(results)
+            for rank, r in enumerate(results, 1):
                 if "id" in r:
                     usage_tracker.log_retrieval(
                         memory_id=r["id"],
                         query=item.query[:200],
                         source=item.source,
+                        rank=rank,
+                        result_count=batch_result_count,
                     )
-            outputs.append({"query": item.query, "results": results, "count": len(results)})
+            outputs.append({"query": item.query, "results": results, "count": batch_result_count})
         usage_tracker.log_api_event("search_batch", count=len(request_body.queries))
         return {"results": outputs, "count": len(outputs)}
     except Exception as e:

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -262,6 +262,26 @@ server.tool(
 );
 
 server.tool(
+  "memory_is_useful",
+  "Submit relevance feedback for a memory retrieved via search. Call after using a memory to signal whether it was helpful. Helps improve future search quality.",
+  {
+    memory_id: z.number().int().describe("ID of the memory to rate"),
+    query: z.string().optional().describe("The search query that surfaced this memory"),
+    signal: z.enum(["useful", "not_useful"]).describe("Whether the memory was helpful"),
+  },
+  async ({ memory_id, query = "", signal }) => {
+    await memoriesRequest("/search/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ memory_id, query, signal }),
+    });
+    return {
+      content: [{ type: "text", text: `Feedback recorded: memory ${memory_id} marked as ${signal}` }],
+    };
+  }
+);
+
+server.tool(
   "memory_conflicts",
   "List memories that conflict with each other. Conflicts are flagged during extraction when contradictory facts are detected. Use to review and resolve contradictions.",
   {},

--- a/tests/test_search_feedback.py
+++ b/tests/test_search_feedback.py
@@ -1,0 +1,205 @@
+"""Tests for search quality feedback — rank tracking, explicit feedback, metrics."""
+
+import importlib
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# --- UsageTracker extensions ---
+
+class TestRankTracking:
+    """Retrieval log should capture result rank position."""
+
+    @pytest.fixture
+    def tracker(self, tmp_path):
+        from usage_tracker import UsageTracker
+        return UsageTracker(str(tmp_path / "usage.db"))
+
+    def test_log_retrieval_with_rank(self, tracker):
+        tracker.log_retrieval(memory_id=1, query="test", source="s", rank=1, result_count=5)
+        tracker.log_retrieval(memory_id=2, query="test", source="s", rank=2, result_count=5)
+        stats = tracker.get_retrieval_stats([1, 2])
+        assert stats[1]["count"] == 1
+        assert stats[2]["count"] == 1
+
+    def test_log_retrieval_without_rank_defaults(self, tracker):
+        """Backward compat: rank defaults to 0 (unknown)."""
+        tracker.log_retrieval(memory_id=1, query="test")
+        stats = tracker.get_retrieval_stats([1])
+        assert stats[1]["count"] == 1
+
+
+class TestSearchFeedback:
+    """Explicit search quality signals stored in search_feedback table."""
+
+    @pytest.fixture
+    def tracker(self, tmp_path):
+        from usage_tracker import UsageTracker
+        return UsageTracker(str(tmp_path / "usage.db"))
+
+    def test_log_feedback_useful(self, tracker):
+        tracker.log_search_feedback(memory_id=1, query="auth", signal="useful")
+        fb = tracker.get_search_quality()
+        assert fb["feedback"]["useful"] >= 1
+
+    def test_log_feedback_not_useful(self, tracker):
+        tracker.log_search_feedback(memory_id=2, query="auth", signal="not_useful")
+        fb = tracker.get_search_quality()
+        assert fb["feedback"]["not_useful"] >= 1
+
+    def test_feedback_with_search_id(self, tracker):
+        tracker.log_search_feedback(memory_id=1, query="q", signal="useful", search_id="abc123")
+        fb = tracker.get_search_quality()
+        assert fb["feedback"]["useful"] >= 1
+
+    def test_invalid_signal_ignored(self, tracker):
+        tracker.log_search_feedback(memory_id=1, query="q", signal="invalid_value")
+        fb = tracker.get_search_quality()
+        assert fb["feedback"]["useful"] == 0
+        assert fb["feedback"]["not_useful"] == 0
+
+
+class TestSearchQualityMetrics:
+    """GET /metrics/search-quality aggregation."""
+
+    @pytest.fixture
+    def tracker(self, tmp_path):
+        from usage_tracker import UsageTracker
+        return UsageTracker(str(tmp_path / "usage.db"))
+
+    def test_empty_metrics(self, tracker):
+        quality = tracker.get_search_quality()
+        assert quality["total_searches"] == 0
+        assert quality["feedback"]["useful"] == 0
+        assert quality["feedback"]["not_useful"] == 0
+        assert quality["rank_distribution"]["top_3"] == 0
+
+    def test_rank_distribution(self, tracker):
+        # 3 results at rank 1-3, 2 at rank 4+
+        for i, rank in enumerate([1, 2, 3, 4, 5]):
+            tracker.log_retrieval(memory_id=i, query="q", rank=rank, result_count=5)
+        quality = tracker.get_search_quality()
+        assert quality["rank_distribution"]["top_3"] == 3
+        assert quality["rank_distribution"]["rank_4_plus"] == 2
+
+    def test_feedback_ratio(self, tracker):
+        tracker.log_search_feedback(memory_id=1, query="q", signal="useful")
+        tracker.log_search_feedback(memory_id=2, query="q", signal="useful")
+        tracker.log_search_feedback(memory_id=3, query="q", signal="not_useful")
+        quality = tracker.get_search_quality()
+        assert quality["feedback"]["useful"] == 2
+        assert quality["feedback"]["not_useful"] == 1
+        assert quality["feedback"]["useful_ratio"] == pytest.approx(2 / 3, rel=0.01)
+
+    def test_search_volume(self, tracker):
+        tracker.log_api_event("search", "s1")
+        tracker.log_api_event("search", "s2")
+        tracker.log_api_event("search", "s1")
+        quality = tracker.get_search_quality()
+        assert quality["total_searches"] == 3
+
+    def test_quality_with_period(self, tracker):
+        tracker.log_api_event("search", "s1")
+        quality = tracker.get_search_quality(period="today")
+        assert quality["total_searches"] >= 1
+        assert quality["period"] == "today"
+
+
+class TestNullTrackerFeedback:
+    """NullTracker must have matching stubs."""
+
+    def test_null_log_search_feedback(self):
+        from usage_tracker import NullTracker
+        t = NullTracker()
+        t.log_search_feedback(memory_id=1, query="q", signal="useful")
+
+    def test_null_get_search_quality(self):
+        from usage_tracker import NullTracker
+        t = NullTracker()
+        result = t.get_search_quality()
+        assert result == {"enabled": False}
+
+
+# --- API Endpoints ---
+
+class TestFeedbackEndpoint:
+    @pytest.fixture
+    def client(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = {
+                "API_KEY": "admin-key",
+                "EXTRACT_PROVIDER": "",
+                "DATA_DIR": tmpdir,
+            }
+            with patch.dict(os.environ, env):
+                import app as app_module
+                importlib.reload(app_module)
+
+                mock_engine = MagicMock()
+                mock_engine.metadata = []
+                app_module.memory = mock_engine
+
+                # Set a real UsageTracker so feedback/quality endpoints work
+                from usage_tracker import UsageTracker
+                app_module.usage_tracker = UsageTracker(os.path.join(tmpdir, "usage.db"))
+
+                yield TestClient(app_module.app), app_module
+
+    def test_post_feedback(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/search/feedback",
+            json={"memory_id": 1, "query": "test query", "signal": "useful"},
+            headers={"X-API-Key": "admin-key"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "recorded"
+
+    def test_post_feedback_not_useful(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/search/feedback",
+            json={"memory_id": 2, "query": "test", "signal": "not_useful"},
+            headers={"X-API-Key": "admin-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_post_feedback_invalid_signal(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/search/feedback",
+            json={"memory_id": 1, "query": "test", "signal": "maybe"},
+            headers={"X-API-Key": "admin-key"},
+        )
+        assert resp.status_code == 422
+
+    def test_get_search_quality(self, client):
+        tc, _ = client
+        resp = tc.get("/metrics/search-quality", headers={"X-API-Key": "admin-key"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "total_searches" in body
+        assert "feedback" in body
+        assert "rank_distribution" in body
+
+    def test_search_quality_with_period(self, client):
+        tc, _ = client
+        resp = tc.get(
+            "/metrics/search-quality?period=30d",
+            headers={"X-API-Key": "admin-key"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["period"] == "30d"
+
+    def test_feedback_requires_auth(self, client):
+        tc, _ = client
+        resp = tc.post(
+            "/search/feedback",
+            json={"memory_id": 1, "query": "test", "signal": "useful"},
+            headers={"X-API-Key": "wrong"},
+        )
+        assert resp.status_code in (401, 403)

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -47,7 +47,7 @@ class NullTracker:
     ) -> None:
         pass
 
-    def log_retrieval(self, memory_id: int, query: str = "", source: str = "") -> None:
+    def log_retrieval(self, memory_id: int, query: str = "", source: str = "", rank: int = 0, result_count: int = 0) -> None:
         pass
 
     def get_retrieval_stats(self, memory_ids: list[int]) -> dict:
@@ -55,6 +55,12 @@ class NullTracker:
 
     def get_unretrieved_memory_ids(self, all_memory_ids: list[int]) -> list[int]:
         return []
+
+    def log_search_feedback(self, memory_id: int, query: str = "", signal: str = "", search_id: str = "") -> None:
+        pass
+
+    def get_search_quality(self, period: str = "7d") -> Dict[str, Any]:
+        return {"enabled": False}
 
     def get_usage(self, period: str = "7d") -> Dict[str, Any]:
         return {"enabled": False}
@@ -94,11 +100,31 @@ class UsageTracker:
                 ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
                 memory_id INTEGER NOT NULL,
                 query TEXT DEFAULT '',
-                source TEXT DEFAULT ''
+                source TEXT DEFAULT '',
+                rank INTEGER DEFAULT 0,
+                result_count INTEGER DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_retrieval_memory ON retrieval_log(memory_id);
             CREATE INDEX IF NOT EXISTS idx_retrieval_ts ON retrieval_log(ts);
+            CREATE TABLE IF NOT EXISTS search_feedback (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                memory_id INTEGER NOT NULL,
+                query TEXT DEFAULT '',
+                signal TEXT NOT NULL,
+                search_id TEXT DEFAULT ''
+            );
+            CREATE INDEX IF NOT EXISTS idx_feedback_ts ON search_feedback(ts);
         """)
+        # Migrate existing DBs: add rank/result_count columns if missing
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(retrieval_log)").fetchall()}
+            if "rank" not in cols:
+                conn.execute("ALTER TABLE retrieval_log ADD COLUMN rank INTEGER DEFAULT 0")
+            if "result_count" not in cols:
+                conn.execute("ALTER TABLE retrieval_log ADD COLUMN result_count INTEGER DEFAULT 0")
+        except Exception:
+            pass
         conn.close()
         logger.info("Usage tracker initialized: %s", db_path)
 
@@ -145,12 +171,12 @@ class UsageTracker:
         except Exception:
             logger.debug("Failed to log extraction tokens", exc_info=True)
 
-    def log_retrieval(self, memory_id: int, query: str = "", source: str = "") -> None:
+    def log_retrieval(self, memory_id: int, query: str = "", source: str = "", rank: int = 0, result_count: int = 0) -> None:
         try:
             conn = self._get_conn()
             conn.execute(
-                "INSERT INTO retrieval_log (memory_id, query, source) VALUES (?, ?, ?)",
-                (memory_id, query[:500], source),
+                "INSERT INTO retrieval_log (memory_id, query, source, rank, result_count) VALUES (?, ?, ?, ?, ?)",
+                (memory_id, query[:500], source, rank, result_count),
             )
             conn.commit()
         except Exception:
@@ -183,6 +209,76 @@ class UsageTracker:
                 conn.execute("SELECT DISTINCT memory_id FROM retrieval_log").fetchall()
             )
             return [mid for mid in all_memory_ids if mid not in retrieved]
+        finally:
+            conn.close()
+
+    VALID_SIGNALS = {"useful", "not_useful"}
+
+    def log_search_feedback(self, memory_id: int, query: str = "", signal: str = "", search_id: str = "") -> None:
+        if signal not in self.VALID_SIGNALS:
+            return
+        try:
+            conn = self._get_conn()
+            conn.execute(
+                "INSERT INTO search_feedback (memory_id, query, signal, search_id) VALUES (?, ?, ?, ?)",
+                (memory_id, query[:500], signal, search_id),
+            )
+            conn.commit()
+        except Exception:
+            logger.debug("Failed to log search feedback", exc_info=True)
+
+    def get_search_quality(self, period: str = "7d") -> Dict[str, Any]:
+        period_filter = PERIOD_SQL.get(period, PERIOD_SQL["7d"])
+        conn = self._connect()
+        conn.row_factory = sqlite3.Row
+        try:
+            # Total searches
+            row = conn.execute(
+                f"SELECT COALESCE(SUM(count), 0) as total FROM api_events WHERE operation = 'search' {period_filter}"
+            ).fetchone()
+            total_searches = row["total"]
+
+            # Rank distribution (only where rank > 0, i.e. tracked)
+            rows = conn.execute(
+                f"SELECT rank, COUNT(*) as cnt FROM retrieval_log WHERE rank > 0 {period_filter} GROUP BY rank"
+            ).fetchall()
+            top_3 = sum(r["cnt"] for r in rows if r["rank"] <= 3)
+            rank_4_plus = sum(r["cnt"] for r in rows if r["rank"] > 3)
+
+            # Feedback counts
+            fb_rows = conn.execute(
+                f"SELECT signal, COUNT(*) as cnt FROM search_feedback WHERE 1=1 {period_filter} GROUP BY signal"
+            ).fetchall()
+            useful = 0
+            not_useful = 0
+            for r in fb_rows:
+                if r["signal"] == "useful":
+                    useful = r["cnt"]
+                elif r["signal"] == "not_useful":
+                    not_useful = r["cnt"]
+            total_fb = useful + not_useful
+            useful_ratio = round(useful / total_fb, 4) if total_fb > 0 else 0.0
+
+            # Unique memories ever retrieved
+            unretrieved_row = conn.execute(
+                "SELECT COUNT(DISTINCT memory_id) as cnt FROM retrieval_log"
+            ).fetchone()
+            retrieved_unique = unretrieved_row["cnt"]
+
+            return {
+                "period": period,
+                "total_searches": total_searches,
+                "rank_distribution": {
+                    "top_3": top_3,
+                    "rank_4_plus": rank_4_plus,
+                },
+                "feedback": {
+                    "useful": useful,
+                    "not_useful": not_useful,
+                    "useful_ratio": useful_ratio,
+                },
+                "unique_memories_retrieved": retrieved_unique,
+            }
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary
- Extend retrieval_log with rank position tracking (implicit signal)
- Add `POST /search/feedback` for explicit useful/not_useful signals
- Add `GET /metrics/search-quality` for aggregated quality metrics
- MCP `memory_is_useful` tool for agent-side feedback

## Test plan
- [x] 19 new tests covering tracker extensions, API endpoints, NullTracker stubs
- [x] 641 total tests passing
- [ ] Manual: submit feedback via MCP tool, verify metrics endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)