### PR TITLE
feat: extraction quality dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -636,12 +636,14 @@ def _run_fallback_extraction(
                 }
             )
 
+    noop_count = sum(1 for a in actions if a.get("action") == "noop")
     return {
         "actions": actions,
         "extracted_count": len(facts),
         "stored_count": stored_count,
         "updated_count": 0,
         "deleted_count": 0,
+        "noop_count": noop_count,
         "mode": "fallback_add",
     }
 
@@ -737,7 +739,19 @@ async def _extract_worker(worker_id: int) -> None:
                     "updated_count": result.get("updated_count", 0),
                     "conflict_count": result.get("conflict_count", 0),
                 })
-            # Log extraction token usage
+            # Log extraction outcome and token usage
+            noop_count = result.get("noop_count")
+            if noop_count is None:
+                noop_count = sum(1 for a in result.get("actions", []) if a.get("action") == "noop")
+            usage_tracker.log_extraction_outcome(
+                source=request_data.get("source", ""),
+                extracted=result.get("extracted_count", 0),
+                stored=result.get("stored_count", 0),
+                updated=result.get("updated_count", 0),
+                deleted=result.get("deleted_count", 0),
+                noop=noop_count,
+                conflict=result.get("conflict_count", 0),
+            )
             tokens = result.get("tokens", {})
             for stage_name in ("extract", "audn"):
                 stage_tokens = tokens.get(stage_name, {})
@@ -1399,6 +1413,17 @@ async def search_quality_metrics(
     """Aggregated search quality metrics — rank distribution, feedback ratios, volume."""
     _get_auth(request)
     return usage_tracker.get_search_quality(period)
+
+
+@app.get("/metrics/extraction-quality")
+async def extraction_quality_metrics(
+    request: Request,
+    period: str = Query("7d", pattern="^(today|7d|30d|all)$"),
+):
+    """Extraction outcome metrics — ADD/UPDATE/DELETE/NOOP ratios, per-source breakdown."""
+    auth = _get_auth(request)
+    _require_admin(auth)
+    return usage_tracker.get_extraction_quality(period)
 
 
 @app.post("/maintenance/embedder/reload")
@@ -2432,6 +2457,16 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
                 "updated_count": result.get("updated_count", 0),
                 "conflict_count": result.get("conflict_count", 0),
             })
+            effective_source = request_body.source or "extract/fallback"
+            usage_tracker.log_extraction_outcome(
+                source=effective_source,
+                extracted=result.get("extracted_count", 0),
+                stored=result.get("stored_count", 0),
+                updated=result.get("updated_count", 0),
+                deleted=result.get("deleted_count", 0),
+                noop=result.get("noop_count", 0),
+                conflict=result.get("conflict_count", 0),
+            )
             logger.info(
                 "Extract fallback completed: job_id=%s source=%s context=%s extracted=%d stored=%d",
                 job_id,

--- a/tests/test_extraction_dashboard.py
+++ b/tests/test_extraction_dashboard.py
@@ -1,0 +1,118 @@
+"""Tests for extraction quality dashboard — outcome tracking and metrics."""
+
+import importlib
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestExtractionOutcomeTracking:
+    """Extraction outcome counts stored in usage DB."""
+
+    @pytest.fixture
+    def tracker(self, tmp_path):
+        from usage_tracker import UsageTracker
+        return UsageTracker(str(tmp_path / "usage.db"))
+
+    def test_log_extraction_outcome(self, tracker):
+        tracker.log_extraction_outcome(
+            source="claude-code/proj",
+            extracted=5, stored=3, updated=1, deleted=0, noop=1, conflict=0,
+        )
+        quality = tracker.get_extraction_quality()
+        assert quality["totals"]["extracted"] == 5
+        assert quality["totals"]["stored"] == 3
+        assert quality["totals"]["noop"] == 1
+
+    def test_multiple_extractions_aggregate(self, tracker):
+        tracker.log_extraction_outcome(source="a", extracted=4, stored=2, updated=1, deleted=0, noop=1, conflict=0)
+        tracker.log_extraction_outcome(source="b", extracted=6, stored=3, updated=0, deleted=1, noop=2, conflict=0)
+        quality = tracker.get_extraction_quality()
+        assert quality["totals"]["extracted"] == 10
+        assert quality["totals"]["stored"] == 5
+        assert quality["totals"]["noop"] == 3
+        assert quality["totals"]["deleted"] == 1
+        assert quality["extraction_count"] == 2
+
+    def test_per_source_breakdown(self, tracker):
+        tracker.log_extraction_outcome(source="claude-code/proj", extracted=5, stored=3, updated=0, deleted=0, noop=2, conflict=0)
+        tracker.log_extraction_outcome(source="learning/proj", extracted=3, stored=1, updated=1, deleted=0, noop=1, conflict=0)
+        quality = tracker.get_extraction_quality()
+        by_source = quality["by_source"]
+        assert "claude-code/proj" in by_source
+        assert by_source["claude-code/proj"]["stored"] == 3
+        assert "learning/proj" in by_source
+        assert by_source["learning/proj"]["updated"] == 1
+
+    def test_noop_ratio(self, tracker):
+        tracker.log_extraction_outcome(source="s", extracted=10, stored=2, updated=1, deleted=0, noop=7, conflict=0)
+        quality = tracker.get_extraction_quality()
+        assert quality["totals"]["noop_ratio"] == pytest.approx(0.7, rel=0.01)
+
+    def test_empty_metrics(self, tracker):
+        quality = tracker.get_extraction_quality()
+        assert quality["extraction_count"] == 0
+        assert quality["totals"]["extracted"] == 0
+        assert quality["totals"]["noop_ratio"] == 0.0
+
+    def test_period_filter(self, tracker):
+        tracker.log_extraction_outcome(source="s", extracted=5, stored=3, updated=0, deleted=0, noop=2, conflict=0)
+        quality = tracker.get_extraction_quality(period="today")
+        assert quality["period"] == "today"
+        assert quality["extraction_count"] >= 1
+
+
+class TestNullTrackerExtractionDashboard:
+    def test_null_log_extraction_outcome(self):
+        from usage_tracker import NullTracker
+        t = NullTracker()
+        t.log_extraction_outcome(source="s", extracted=5, stored=3, updated=0, deleted=0, noop=2, conflict=0)
+
+    def test_null_get_extraction_quality(self):
+        from usage_tracker import NullTracker
+        t = NullTracker()
+        result = t.get_extraction_quality()
+        assert result == {"enabled": False}
+
+
+class TestExtractionQualityEndpoint:
+    @pytest.fixture
+    def client(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = {"API_KEY": "admin-key", "EXTRACT_PROVIDER": "", "DATA_DIR": tmpdir}
+            with patch.dict(os.environ, env):
+                import app as app_module
+                importlib.reload(app_module)
+
+                mock_engine = MagicMock()
+                mock_engine.metadata = []
+                app_module.memory = mock_engine
+
+                from usage_tracker import UsageTracker
+                tracker = UsageTracker(os.path.join(tmpdir, "usage.db"))
+                app_module.usage_tracker = tracker
+
+                yield TestClient(app_module.app), tracker
+
+    def test_get_extraction_quality(self, client):
+        tc, tracker = client
+        tracker.log_extraction_outcome(source="test", extracted=5, stored=3, updated=1, deleted=0, noop=1, conflict=0)
+        resp = tc.get("/metrics/extraction-quality", headers={"X-API-Key": "admin-key"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["extraction_count"] == 1
+        assert body["totals"]["stored"] == 3
+
+    def test_extraction_quality_with_period(self, client):
+        tc, _ = client
+        resp = tc.get("/metrics/extraction-quality?period=30d", headers={"X-API-Key": "admin-key"})
+        assert resp.status_code == 200
+        assert resp.json()["period"] == "30d"
+
+    def test_extraction_quality_requires_auth(self, client):
+        tc, _ = client
+        resp = tc.get("/metrics/extraction-quality", headers={"X-API-Key": "wrong"})
+        assert resp.status_code in (401, 403)

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -62,6 +62,13 @@ class NullTracker:
     def get_search_quality(self, period: str = "7d") -> Dict[str, Any]:
         return {"enabled": False}
 
+    def log_extraction_outcome(self, source: str = "", extracted: int = 0, stored: int = 0,
+                               updated: int = 0, deleted: int = 0, noop: int = 0, conflict: int = 0) -> None:
+        pass
+
+    def get_extraction_quality(self, period: str = "7d") -> Dict[str, Any]:
+        return {"enabled": False}
+
     def get_usage(self, period: str = "7d") -> Dict[str, Any]:
         return {"enabled": False}
 
@@ -115,6 +122,18 @@ class UsageTracker:
                 search_id TEXT DEFAULT ''
             );
             CREATE INDEX IF NOT EXISTS idx_feedback_ts ON search_feedback(ts);
+            CREATE TABLE IF NOT EXISTS extraction_outcomes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                source TEXT DEFAULT '',
+                extracted INTEGER DEFAULT 0,
+                stored INTEGER DEFAULT 0,
+                updated INTEGER DEFAULT 0,
+                deleted INTEGER DEFAULT 0,
+                noop INTEGER DEFAULT 0,
+                conflict INTEGER DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_extraction_outcomes_ts ON extraction_outcomes(ts);
         """)
         # Migrate existing DBs: add rank/result_count columns if missing
         try:
@@ -278,6 +297,78 @@ class UsageTracker:
                     "useful_ratio": useful_ratio,
                 },
                 "unique_memories_retrieved": retrieved_unique,
+            }
+        finally:
+            conn.close()
+
+    def log_extraction_outcome(self, source: str = "", extracted: int = 0, stored: int = 0,
+                               updated: int = 0, deleted: int = 0, noop: int = 0, conflict: int = 0) -> None:
+        try:
+            conn = self._get_conn()
+            conn.execute(
+                "INSERT INTO extraction_outcomes (source, extracted, stored, updated, deleted, noop, conflict) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (source, extracted, stored, updated, deleted, noop, conflict),
+            )
+            conn.commit()
+        except Exception:
+            logger.debug("Failed to log extraction outcome", exc_info=True)
+
+    def get_extraction_quality(self, period: str = "7d") -> Dict[str, Any]:
+        period_filter = PERIOD_SQL.get(period, PERIOD_SQL["7d"])
+        conn = self._connect()
+        conn.row_factory = sqlite3.Row
+        try:
+            # Aggregated totals
+            row = conn.execute(
+                f"SELECT COUNT(*) as cnt, "
+                f"COALESCE(SUM(extracted), 0) as extracted, "
+                f"COALESCE(SUM(stored), 0) as stored, "
+                f"COALESCE(SUM(updated), 0) as updated, "
+                f"COALESCE(SUM(deleted), 0) as deleted, "
+                f"COALESCE(SUM(noop), 0) as noop, "
+                f"COALESCE(SUM(conflict), 0) as conflict "
+                f"FROM extraction_outcomes WHERE 1=1 {period_filter}"
+            ).fetchone()
+            extraction_count = row["cnt"]
+            total_extracted = row["extracted"]
+            noop_ratio = round(row["noop"] / total_extracted, 4) if total_extracted > 0 else 0.0
+
+            # Per-source breakdown
+            source_rows = conn.execute(
+                f"SELECT source, "
+                f"SUM(extracted) as extracted, SUM(stored) as stored, "
+                f"SUM(updated) as updated, SUM(deleted) as deleted, "
+                f"SUM(noop) as noop, SUM(conflict) as conflict, "
+                f"COUNT(*) as cnt "
+                f"FROM extraction_outcomes WHERE 1=1 {period_filter} GROUP BY source"
+            ).fetchall()
+            by_source = {}
+            for sr in source_rows:
+                src = sr["source"] or "(unknown)"
+                by_source[src] = {
+                    "extraction_count": sr["cnt"],
+                    "extracted": sr["extracted"],
+                    "stored": sr["stored"],
+                    "updated": sr["updated"],
+                    "deleted": sr["deleted"],
+                    "noop": sr["noop"],
+                    "conflict": sr["conflict"],
+                }
+
+            return {
+                "period": period,
+                "extraction_count": extraction_count,
+                "totals": {
+                    "extracted": row["extracted"],
+                    "stored": row["stored"],
+                    "updated": row["updated"],
+                    "deleted": row["deleted"],
+                    "noop": row["noop"],
+                    "conflict": row["conflict"],
+                    "noop_ratio": noop_ratio,
+                },
+                "by_source": by_source,
             }
         finally:
             conn.close()


### PR DESCRIPTION
## Summary
- Track ADD/UPDATE/DELETE/NOOP/conflict counts per extraction in new `extraction_outcomes` table
- `GET /metrics/extraction-quality` endpoint with period filter and per-source breakdown
- NOOP ratio calculation to detect over-aggressive triggers
- Wired into both async worker and fallback extraction paths

## Test plan
- [x] 11 new tests covering tracker, NullTracker, and API endpoint
- [x] 633 total tests passing
- [ ] Manual: run extraction, verify outcome appears in metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)