### PR TITLE
feat: audit log for multi-user operations

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ from embedder_reloader import EmbedderAutoReloadController
 from key_store import KeyStore
 from memory_engine import MemoryEngine
 from runtime_memory import MemoryTrimmer
+from audit_log import AuditLog, NullAuditLog
 from usage_tracker import UsageTracker, NullTracker
 
 # -- Logging ------------------------------------------------------------------
@@ -165,6 +166,7 @@ embedder_auto_reloader = EmbedderAutoReloadController(
     max_queue_depth=EMBEDDER_AUTO_RELOAD_MAX_QUEUE_DEPTH,
 )
 usage_tracker: UsageTracker | NullTracker = NullTracker()  # replaced in lifespan if enabled
+audit_log: AuditLog | NullAuditLog = NullAuditLog()  # replaced in lifespan if enabled
 metrics_started_at = time.time()
 metrics_lock = threading.Lock()
 request_metrics: Dict[str, Dict[str, Any]] = {}
@@ -278,6 +280,20 @@ async def verify_api_key(request: Request):
 
 def _get_auth(request: Request) -> AuthContext:
     return getattr(request.state, "auth", AuthContext.unrestricted())
+
+
+def _audit(request: Request, action: str, resource_id: str = "", source: str = "") -> None:
+    """Log an audit entry from the current request context."""
+    auth = _get_auth(request)
+    ip = request.client.host if request.client else ""
+    audit_log.log(
+        action=action,
+        key_id=auth.key_id or "env",
+        key_name=auth.key_name or "",
+        resource_id=resource_id,
+        source_prefix=source,
+        ip=ip,
+    )
 
 
 def _require_write(auth: AuthContext, source: str) -> None:
@@ -955,6 +971,10 @@ async def lifespan(app: FastAPI):
     if _env_bool("USAGE_TRACKING", False):
         usage_tracker = UsageTracker(os.path.join(DATA_DIR, "usage.db"))
         logger.info("Usage tracking enabled")
+    global audit_log
+    if _env_bool("AUDIT_LOG", False):
+        audit_log = AuditLog(os.path.join(DATA_DIR, "audit.db"))
+        logger.info("Audit logging enabled")
     global key_store
     key_store = KeyStore(os.path.join(DATA_DIR, "keys.db"))
     logger.info("Key store initialized")
@@ -1426,6 +1446,33 @@ async def extraction_quality_metrics(
     return usage_tracker.get_extraction_quality(period)
 
 
+@app.get("/audit")
+async def get_audit_log(
+    request: Request,
+    action: Optional[str] = None,
+    key_id: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """Query the audit trail. Admin only."""
+    auth = _get_auth(request)
+    _require_admin(auth)
+    entries = audit_log.query(action=action, key_id=key_id, limit=limit, offset=offset)
+    return {"entries": entries, "count": len(entries), "total": audit_log.count(action=action, key_id=key_id)}
+
+
+@app.post("/audit/purge")
+async def purge_audit_log(
+    request: Request,
+    retention_days: int = Query(90, ge=1, le=365),
+):
+    """Purge audit entries older than retention period. Admin only."""
+    auth = _get_auth(request)
+    _require_admin(auth)
+    purged = audit_log.purge(retention_days=retention_days)
+    return {"purged": purged, "retention_days": retention_days}
+
+
 @app.post("/maintenance/embedder/reload")
 async def reload_embedder(request: Request):
     """Reload in-process embedder runtime and release old inference objects."""
@@ -1675,9 +1722,11 @@ async def add_memory(request_body: AddMemoryRequest, request: Request):
             deduplicate=request_body.deduplicate,
         )
         usage_tracker.log_api_event("add", request_body.source)
+        result_id = ids[0] if ids else None
+        _audit(request, "add", resource_id=str(result_id or ""), source=request_body.source)
         return {
             "success": True,
-            "id": ids[0] if ids else None,
+            "id": result_id,
             "message": "Memory added successfully" if ids else "Duplicate skipped",
         }
     except Exception as e:
@@ -1752,8 +1801,10 @@ async def delete_memory(memory_id: int, request: Request):
         if auth.prefixes is not None:
             existing = memory.get_memory(memory_id)
             _require_write(auth, existing.get("source", ""))
+        delete_source = existing.get("source", "") if auth.prefixes is not None else ""
         result = memory.delete_memory(memory_id)
         usage_tracker.log_api_event("delete")
+        _audit(request, "delete", resource_id=str(memory_id), source=delete_source)
         return {"success": True, **result}
     except HTTPException:
         raise
@@ -2483,6 +2534,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
         finally:
             _trim_finished_extract_jobs()
 
+        _audit(request, "extract", source=request_body.source or "extract/fallback")
         return {
             "job_id": job_id,
             "status": extract_jobs[job_id]["status"],
@@ -2492,6 +2544,7 @@ async def memory_extract(request_body: ExtractRequest, request: Request):
 
     _ensure_extract_workers_started()
     usage_tracker.log_api_event("extract", request_body.source)
+    _audit(request, "extract", source=request_body.source)
     job_id = uuid4().hex
     extract_jobs[job_id] = {
         "job_id": job_id,

--- a/audit_log.py
+++ b/audit_log.py
@@ -1,0 +1,144 @@
+"""Append-only audit trail for multi-user memory operations.
+
+Enabled via AUDIT_LOG=true env var. Records who did what, when, from where.
+"""
+
+import logging
+import sqlite3
+import threading
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("memories.audit")
+
+
+class NullAuditLog:
+    """No-op when audit logging is disabled."""
+
+    def log(self, **kwargs) -> None:
+        pass
+
+    def query(self, **kwargs) -> List[Dict[str, Any]]:
+        return []
+
+    def count(self, action=None, key_id=None, **kwargs) -> int:
+        return 0
+
+    def purge(self, retention_days: int = 90) -> int:
+        return 0
+
+
+class AuditLog:
+    """SQLite-backed append-only audit trail."""
+
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        self._local = threading.local()
+        conn = self._connect()
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                action TEXT NOT NULL,
+                key_id TEXT DEFAULT '',
+                key_name TEXT DEFAULT '',
+                resource_id TEXT DEFAULT '',
+                source_prefix TEXT DEFAULT '',
+                ip TEXT DEFAULT ''
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(ts);
+            CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action);
+            CREATE INDEX IF NOT EXISTS idx_audit_key ON audit_log(key_id);
+        """)
+        conn.close()
+        logger.info("Audit log initialized: %s", db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = self._connect()
+        return self._local.conn
+
+    def log(
+        self,
+        action: str,
+        key_id: str = "",
+        key_name: str = "",
+        resource_id: str = "",
+        source_prefix: str = "",
+        ip: str = "",
+    ) -> None:
+        try:
+            conn = self._get_conn()
+            conn.execute(
+                "INSERT INTO audit_log (action, key_id, key_name, resource_id, source_prefix, ip) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (action, key_id, key_name, resource_id, source_prefix, ip),
+            )
+            conn.commit()
+        except Exception:
+            logger.debug("Failed to write audit entry", exc_info=True)
+
+    def query(
+        self,
+        action: Optional[str] = None,
+        key_id: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        conn = self._connect()
+        conn.row_factory = sqlite3.Row
+        try:
+            clauses = []
+            params: list = []
+            if action:
+                clauses.append("action = ?")
+                params.append(action)
+            if key_id:
+                clauses.append("key_id = ?")
+                params.append(key_id)
+            where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+            rows = conn.execute(
+                f"SELECT * FROM audit_log {where} ORDER BY id DESC LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def count(self, action: Optional[str] = None, key_id: Optional[str] = None) -> int:
+        conn = self._connect()
+        try:
+            clauses: list = []
+            params: list = []
+            if action:
+                clauses.append("action = ?")
+                params.append(action)
+            if key_id:
+                clauses.append("key_id = ?")
+                params.append(key_id)
+            where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+            row = conn.execute(f"SELECT COUNT(*) FROM audit_log {where}", params).fetchone()
+            return row[0]
+        finally:
+            conn.close()
+
+    def purge(self, retention_days: int = 90) -> int:
+        conn = self._get_conn()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM audit_log WHERE ts < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', ?)",
+                (f"-{retention_days} days",),
+            )
+            conn.commit()
+            purged = cursor.rowcount
+            if purged > 0:
+                logger.info("Purged %d audit entries older than %d days", purged, retention_days)
+            return purged
+        except Exception:
+            logger.debug("Failed to purge audit log", exc_info=True)
+            return 0

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,147 @@
+"""Tests for audit log — append-only trail with retention and query."""
+
+import importlib
+import os
+import tempfile
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestAuditLog:
+    """Core audit log functionality."""
+
+    @pytest.fixture
+    def audit(self, tmp_path):
+        from audit_log import AuditLog
+        return AuditLog(str(tmp_path / "audit.db"))
+
+    def test_log_entry(self, audit):
+        audit.log(action="search", key_id="k1", key_name="test-key", source_prefix="claude-code/*", ip="127.0.0.1")
+        entries = audit.query(limit=10)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "search"
+        assert entries[0]["key_id"] == "k1"
+
+    def test_log_with_resource_id(self, audit):
+        audit.log(action="delete", key_id="k1", resource_id="42")
+        entries = audit.query(limit=10)
+        assert entries[0]["resource_id"] == "42"
+
+    def test_query_by_action(self, audit):
+        audit.log(action="search", key_id="k1")
+        audit.log(action="add", key_id="k1")
+        audit.log(action="delete", key_id="k1")
+        entries = audit.query(action="add")
+        assert len(entries) == 1
+        assert entries[0]["action"] == "add"
+
+    def test_query_by_key_id(self, audit):
+        audit.log(action="search", key_id="k1")
+        audit.log(action="search", key_id="k2")
+        entries = audit.query(key_id="k2")
+        assert len(entries) == 1
+
+    def test_query_limit_and_offset(self, audit):
+        for i in range(10):
+            audit.log(action="search", key_id="k1")
+        entries = audit.query(limit=3, offset=2)
+        assert len(entries) == 3
+
+    def test_query_returns_newest_first(self, audit):
+        audit.log(action="search", key_id="k1")
+        audit.log(action="add", key_id="k2")
+        entries = audit.query(limit=10)
+        assert entries[0]["action"] == "add"  # most recent
+        assert entries[1]["action"] == "search"
+
+    def test_retention_purge(self, audit):
+        # Insert an old entry by manipulating the DB directly
+        import sqlite3
+        conn = sqlite3.connect(audit._db_path)
+        conn.execute(
+            "INSERT INTO audit_log (ts, action, key_id) VALUES (datetime('now', '-100 days'), 'old_action', 'k1')"
+        )
+        conn.commit()
+        conn.close()
+
+        audit.log(action="new_action", key_id="k2")
+        purged = audit.purge(retention_days=90)
+        assert purged >= 1
+        entries = audit.query(limit=100)
+        assert all(e["action"] != "old_action" for e in entries)
+
+    def test_count(self, audit):
+        audit.log(action="search", key_id="k1")
+        audit.log(action="add", key_id="k2")
+        assert audit.count() == 2
+        assert audit.count(action="search") == 1
+
+
+class TestNullAuditLog:
+    def test_null_log(self):
+        from audit_log import NullAuditLog
+        a = NullAuditLog()
+        a.log(action="search", key_id="k1")
+
+    def test_null_query(self):
+        from audit_log import NullAuditLog
+        a = NullAuditLog()
+        assert a.query() == []
+
+    def test_null_count(self):
+        from audit_log import NullAuditLog
+        a = NullAuditLog()
+        assert a.count() == 0
+
+
+class TestAuditEndpoint:
+    @pytest.fixture
+    def client(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = {"API_KEY": "admin-key", "EXTRACT_PROVIDER": "", "DATA_DIR": tmpdir, "AUDIT_LOG": "true"}
+            with patch.dict(os.environ, env):
+                import app as app_module
+                importlib.reload(app_module)
+
+                mock_engine = MagicMock()
+                mock_engine.metadata = []
+                app_module.memory = mock_engine
+
+                from audit_log import AuditLog
+                app_module.audit_log = AuditLog(os.path.join(tmpdir, "audit.db"))
+
+                yield TestClient(app_module.app), app_module
+
+    def test_get_audit_log(self, client):
+        tc, mod = client
+        mod.audit_log.log(action="search", key_id="env", ip="127.0.0.1")
+        resp = tc.get("/audit", headers={"X-API-Key": "admin-key"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "entries" in body
+        assert len(body["entries"]) == 1
+
+    def test_audit_filter_by_action(self, client):
+        tc, mod = client
+        mod.audit_log.log(action="search", key_id="k1")
+        mod.audit_log.log(action="add", key_id="k1")
+        resp = tc.get("/audit?action=search", headers={"X-API-Key": "admin-key"})
+        assert len(resp.json()["entries"]) == 1
+
+    def test_audit_requires_admin(self, client):
+        tc, mod = client
+        from key_store import KeyStore
+        ks = KeyStore(os.path.join(mod.DATA_DIR, "keys.db"))
+        mod.key_store = ks
+        created = ks.create_key(name="reader", role="read-only", prefixes=["test/*"])
+        resp = tc.get("/audit", headers={"X-API-Key": created["key"]})
+        assert resp.status_code == 403
+
+    def test_audit_purge_endpoint(self, client):
+        tc, mod = client
+        resp = tc.post("/audit/purge?retention_days=90", headers={"X-API-Key": "admin-key"})
+        assert resp.status_code == 200
+        assert "purged" in resp.json()


### PR DESCRIPTION
## Summary
- Append-only SQLite audit trail tracking who did what, when, from where
- `GET /audit` with action/key_id filters and pagination (admin-only)
- `POST /audit/purge` with configurable retention (default 90 days)
- Wired into add, delete, and extract operations via `_audit()` helper
- Opt-in via `AUDIT_LOG=true` env var, NullAuditLog when disabled

## Test plan
- [x] 15 new tests covering log, query, purge, NullAuditLog, and API endpoints
- [x] 637 total tests passing
- [ ] Manual: perform operations, verify audit trail via GET /audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)