### PR TITLE
feat: zero-clone install via GHCR image + npm package

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: divyekant/memories
+
+jobs:
+  build-and-push:
+    name: Build and push — ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [core, extract]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          if [[ "${{ matrix.target }}" == "core" ]]; then
+            SUFFIX=""
+            STABLE_TAG="latest"
+          else
+            SUFFIX="-extract"
+            STABLE_TAG="extract"
+          fi
+
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"          # strip leading 'v'
+            MAJOR_MINOR="${VERSION%.*}"     # e.g. 5.0 from 5.0.1
+            TAGS="${IMAGE}:${VERSION}${SUFFIX},${IMAGE}:${MAJOR_MINOR}${SUFFIX},${IMAGE}:${STABLE_TAG}"
+          else
+            # main branch or manual dispatch → edge channel
+            TAGS="${IMAGE}:edge${SUFFIX}"
+          fi
+
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,41 @@
+name: Publish npm Package
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish memories-mcp to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for --provenance
+
+    defaults:
+      run:
+        working-directory: mcp-server
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync hooks and assets (prepack)
+        run: npm run prepack
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -218,27 +218,26 @@ The MCP server gives Claude Code native `memory_search`, `memory_add`, `memory_e
 
 **Setup:**
 
-1. Install the MCP server dependencies:
-
-```bash
-cd memories/mcp-server
-npm install
-```
-
-2. Register the MCP server with Claude Code (user scope — available in every project):
+1. Register the MCP server with Claude Code (user scope — available in every project):
 
 ```bash
 claude mcp add -s user \
   -e MEMORIES_URL=http://localhost:8900 \
   -e MEMORIES_API_KEY=your-api-key-here \
-  -- memories node /path/to/memories/mcp-server/index.js
+  -- memories npx -y memories-mcp
 ```
 
 This writes to `~/.claude.json`. **Do not** add MCP servers to `~/.claude/settings.json` or `~/.claude/.mcp.json` — Claude Code CLI does not read MCP config from those files (Claude Desktop uses separate config, see below).
 
-3. Restart Claude Code. The tools are now available in every project.
+2. Restart Claude Code. The tools are now available in every project.
 
-4. (Optional) Install the **Memories skill** for disciplined memory capture and proactive recall:
+3. (Optional) Install the **automatic memory layer** (hooks for proactive recall and extraction):
+
+```bash
+npx memories-mcp install --claude
+```
+
+4. (Optional) Install the **Memories skill** for disciplined memory capture and proactive recall. Clone the repo and symlink:
 
 ```bash
 mkdir -p ~/.claude/skills/memories
@@ -260,7 +259,7 @@ For a **single project only**, use project scope instead:
 claude mcp add -s project \
   -e MEMORIES_URL=http://localhost:8900 \
   -e MEMORIES_API_KEY=your-api-key-here \
-  -- memories node /path/to/memories/mcp-server/index.js
+  -- memories npx -y memories-mcp
 ```
 
 ---
@@ -271,21 +270,14 @@ Same MCP server, different config file. Claude Desktop reads MCP config from its
 
 **Setup:**
 
-1. Install dependencies (same as above):
-
-```bash
-cd memories/mcp-server
-npm install
-```
-
-2. Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+1. Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
   "mcpServers": {
     "memories": {
-      "command": "node",
-      "args": ["/path/to/memories/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["-y", "memories-mcp"],
       "env": {
         "MEMORIES_URL": "http://localhost:8900",
         "MEMORIES_API_KEY": "your-api-key-here"
@@ -295,7 +287,7 @@ npm install
 }
 ```
 
-3. Restart the Claude Desktop app. Memory tools appear in chat and cowork mode.
+2. Restart the Claude Desktop app. Memory tools appear in chat and cowork mode.
 
 ---
 
@@ -328,19 +320,12 @@ Codex supports MCP natively via `~/.codex/config.toml`.
 
 **Setup:**
 
-1. Install dependencies:
-
-```bash
-cd memories/mcp-server
-npm install
-```
-
-2. Add to `~/.codex/config.toml`:
+1. Add to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.memories]
-command = "node"
-args = ["/path/to/memories/mcp-server/index.js"]
+command = "npx"
+args = ["-y", "memories-mcp"]
 
 [mcp_servers.memories.env]
 MEMORIES_URL = "http://localhost:8900"
@@ -354,15 +339,12 @@ MEMORIES_SOURCE_PREFIXES="your-authorized-prefix/{project},learning/{project},wi
 MEMORIES_EXTRACT_SOURCE="your-authorized-prefix/{project}"
 ```
 
-3. Restart Codex. The `memory_search`, `memory_add`, `memory_extract`, `memory_delete`, `memory_delete_by_source`, `memory_count`, `memory_list`, `memory_stats`, `memory_is_novel`, and other tools will be available.
+2. Restart Codex. The `memory_search`, `memory_add`, `memory_extract`, `memory_delete`, `memory_delete_by_source`, `memory_count`, `memory_list`, `memory_stats`, `memory_is_novel`, and other tools will be available.
 
 **Automatic memory layer for Codex:**
 
 ```bash
-cd memories/mcp-server
-npm install
-cd ..
-./integrations/claude-code/install.sh --codex
+npx memories-mcp install --codex
 ```
 
 This configures:
@@ -372,8 +354,7 @@ This configures:
 - default `developer_instructions` (if not already set) to bias `memory_search` usage on each turn
 - hook env loading from `~/.config/memories/env` (or `MEMORIES_ENV_FILE`) for `MEMORIES_URL`, `MEMORIES_API_KEY`, and optional source overrides (`MEMORIES_SOURCE_PREFIXES`, `MEMORIES_EXTRACT_SOURCE`)
 
-The installer requires `jq`, `curl`, and a running Memories service (`/health` must respond).
-For scoped API keys, set `MEMORIES_SOURCE_PREFIXES` and `MEMORIES_EXTRACT_SOURCE` so hook reads/writes stay inside authorized prefixes.
+Requires a running Memories service (`/health` must respond). For scoped API keys, set `MEMORIES_SOURCE_PREFIXES` and `MEMORIES_EXTRACT_SOURCE` so hook reads/writes stay inside authorized prefixes.
 
 Codex uses `~/.codex/settings.json` for lifecycle hooks and `~/.codex/config.toml` for MCP + developer instructions.
 
@@ -393,14 +374,7 @@ Cursor supports MCP with the same server.
 
 **Setup:**
 
-1. Install dependencies:
-
-```bash
-cd memories/mcp-server
-npm install
-```
-
-2. Add to Cursor MCP config:
+1. Add to Cursor MCP config:
 - Global: `~/.cursor/mcp.json`
 - Project: `.cursor/mcp.json`
 
@@ -408,8 +382,8 @@ npm install
 {
   "mcpServers": {
     "memories": {
-      "command": "node",
-      "args": ["/path/to/memories/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["-y", "memories-mcp"],
       "env": {
         "MEMORIES_URL": "http://localhost:8900",
         "MEMORIES_API_KEY": "your-api-key-here"
@@ -419,9 +393,13 @@ npm install
 }
 ```
 
-3. Restart Cursor.
+2. Restart Cursor.
 
-Cursor also supports the full hook lifecycle via its "Third-party skills" feature. Run `./integrations/claude-code/install.sh --cursor` to install hooks alongside the MCP config.
+Cursor also supports the full hook lifecycle via its "Third-party skills" feature. Run the one-liner to install hooks alongside the MCP config:
+
+```bash
+npx memories-mcp install --cursor
+```
 
 **Multi-backend:** Cursor uses the same hook scripts as Claude Code, so [multi-backend routing](#multi-backend-routing-optional) works automatically when configured.
 
@@ -1028,45 +1006,37 @@ Codex uses `~/.codex/settings.json` for these hooks and `~/.codex/config.toml` f
 ### Quick setup
 
 **Prerequisites:**
-- `jq` and `curl` installed (required by installer)
-- running Memories service (`curl -s http://localhost:8900/health | jq .`)
-- if installing Codex integration, MCP deps installed:
-
-```bash
-cd memories/mcp-server
-npm install
-```
+- Running Memories service (`curl -s http://localhost:8900/health`)
 
 **One-command auto-detect installer (recommended):**
+
 ```bash
-./integrations/claude-code/install.sh --auto
+npx memories-mcp install
 ```
 
-This detects and configures any available targets on your machine:
-- Claude Code hooks (`~/.claude/settings.json`)
+This auto-detects installed tools and configures:
+- Claude Code hooks (`~/.claude/settings.json`) + MCP
 - Codex hooks (`~/.codex/settings.json`) + MCP/developer instructions (`~/.codex/config.toml`)
+- Cursor MCP config (`~/.cursor/mcp.json`) + hooks
 - OpenClaw skill (`~/.openclaw/skills/memories/SKILL.md`)
 
-Cursor is supported via manual MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json`).
+The installer writes runtime config to `~/.config/memories/env` for `MEMORIES_URL`, optional `MEMORIES_API_KEY`, and optional source overrides (`MEMORIES_SOURCE_PREFIXES` / `MEMORIES_EXTRACT_SOURCE`).
 
-The installer writes runtime config to:
-- `~/.config/memories/env` for hook vars (`MEMORIES_URL`, optional `MEMORIES_API_KEY`, optional `MEMORIES_SOURCE_PREFIXES` / `MEMORIES_EXTRACT_SOURCE` to override default source families)
-- repo `.env` for extraction vars (`EXTRACT_PROVIDER`, provider keys/URL)
+Claude/Cursor hooks also support `MEMORIES_SOURCE_PREFIXES` in `~/.config/memories/env` — a comma-separated list of source prefix templates (default: `claude-code/{project},learning/{project},wip/{project}`).
 
-Claude/Cursor read hooks also support an optional `MEMORIES_SOURCE_PREFIXES` env var in
-`~/.config/memories/env`. It is a comma-separated list of source prefix templates and
-defaults to `claude-code/{project},learning/{project},wip/{project}`.
+**Target specific tools:**
 
-**Target only Claude, Cursor, or Codex:**
 ```bash
-./integrations/claude-code/install.sh --claude
-./integrations/claude-code/install.sh --cursor
-./integrations/claude-code/install.sh --codex
+npx memories-mcp install --claude
+npx memories-mcp install --cursor
+npx memories-mcp install --codex
+npx memories-mcp install --openclaw
 ```
 
-**Target only OpenClaw:**
+**Uninstall:**
+
 ```bash
-./integrations/claude-code/install.sh --openclaw
+npx memories-mcp uninstall
 ```
 
 **LLM-assisted setup:** Feed [`integrations/QUICKSTART-LLM.md`](integrations/QUICKSTART-LLM.md) to your AI assistant and it will configure everything automatically.

--- a/README.md
+++ b/README.md
@@ -24,27 +24,44 @@ Start here:
 
 ## API Quick Start
 
+**Option A — no clone required (pre-built image):**
+
+```bash
+# 1. Download the compose file and start
+curl -fsSL https://raw.githubusercontent.com/divyekant/memories/main/docker-compose.standalone.yml -o docker-compose.yml
+docker compose up -d
+
+# 2. Verify
+curl http://localhost:8900/health
+```
+
+**Option B — clone and build from source:**
+
 ```bash
 # 1. Clone and build
 git clone git@github.com:divyekant/memories.git
 cd memories
-docker compose -f docker-compose.snippet.yml up -d
+docker compose up -d
 
 # 2. Verify
 curl http://localhost:8900/health
+```
 
-# 3. Add a memory
+**Then add and search memories:**
+
+```bash
+# Add a memory
 curl -X POST http://localhost:8900/memory/add \
   -H "Content-Type: application/json" \
   -d '{"text": "Always use TypeScript strict mode", "source": "standards.md"}'
 
-# 4. Search
+# Search
 curl -X POST http://localhost:8900/search \
   -H "Content-Type: application/json" \
   -d '{"query": "TypeScript config", "k": 3, "hybrid": true}'
 ```
 
-The service runs at **http://localhost:8900**. API docs at http://localhost:8900/docs. Web UI at http://localhost:8900/ui.
+The service runs at **[http://localhost:8900](http://localhost:8900)**. API docs at [http://localhost:8900/docs](http://localhost:8900/docs). Web UI at [http://localhost:8900/ui](http://localhost:8900/ui).
 
 ### Web UI
 

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,101 @@
+# Standalone compose file — no clone required.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/divyekant/memories/main/docker-compose.standalone.yml -o docker-compose.yml
+#   docker compose up -d
+#
+# To use the extraction-capable image (Anthropic/OpenAI/Ollama extraction):
+#   MEMORIES_IMAGE_TAG=extract docker compose up -d
+#
+# Set API_KEY to enable authentication:
+#   API_KEY=my-secret docker compose up -d
+
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.15.4
+    container_name: qdrant
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
+    volumes:
+      - qdrant-storage:/qdrant/storage
+
+  memories:
+    image: ghcr.io/divyekant/memories:${MEMORIES_IMAGE_TAG:-latest}
+    container_name: memories
+    restart: unless-stopped
+    depends_on:
+      - qdrant
+    mem_limit: ${MEMORIES_MEM_LIMIT:-3g}
+    ports:
+      - "8900:8000"
+    volumes:
+      - memories-data:/data
+      # Optional: mount a directory of text files to index
+      # - /path/to/your/documents:/workspace:ro
+    environment:
+      - DATA_DIR=/data
+      # - WORKSPACE_DIR=/workspace  # Uncomment if mounting documents
+      - API_KEY=${API_KEY:-}
+      - MODEL_NAME=all-MiniLM-L6-v2
+      # Embedding provider: onnx (local, default) or openai (BYOK)
+      - EMBED_PROVIDER=${EMBED_PROVIDER:-onnx}
+      - EMBED_MODEL=${EMBED_MODEL:-}
+      - MAX_BACKUPS=10
+      # Qdrant backend
+      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
+      - QDRANT_API_KEY=${QDRANT_API_KEY:-}
+      - QDRANT_COLLECTION=${QDRANT_COLLECTION:-memories}
+      - QDRANT_WAIT=${QDRANT_WAIT:-true}
+      - QDRANT_WRITE_ORDERING=${QDRANT_WRITE_ORDERING:-strong}
+      - QDRANT_READ_CONSISTENCY=${QDRANT_READ_CONSISTENCY:-majority}
+      - QDRANT_REPLICATION_FACTOR=${QDRANT_REPLICATION_FACTOR:-1}
+      - QDRANT_WRITE_CONSISTENCY_FACTOR=${QDRANT_WRITE_CONSISTENCY_FACTOR:-1}
+      # Optional extraction provider pass-through
+      - EXTRACT_PROVIDER=${EXTRACT_PROVIDER:-}
+      - EXTRACT_MODEL=${EXTRACT_MODEL:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OLLAMA_URL=${OLLAMA_URL:-}
+      - CHATGPT_REFRESH_TOKEN=${CHATGPT_REFRESH_TOKEN:-}
+      - CHATGPT_CLIENT_ID=${CHATGPT_CLIENT_ID:-}
+      - EXTRACT_FALLBACK_ADD=${EXTRACT_FALLBACK_ADD:-false}
+      # Usage analytics (opt-in)
+      - USAGE_TRACKING=${USAGE_TRACKING:-}
+      # Audit log (opt-in)
+      - AUDIT_LOG=${AUDIT_LOG:-false}
+      # Scheduled maintenance
+      - MAINTENANCE_ENABLED=${MAINTENANCE_ENABLED:-false}
+      # Allocator guardrails
+      - MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-2}
+      - MALLOC_TRIM_THRESHOLD_=${MALLOC_TRIM_THRESHOLD_:-131072}
+      - MALLOC_MMAP_THRESHOLD_=${MALLOC_MMAP_THRESHOLD_:-131072}
+      # Embedder auto-reload
+      - EMBEDDER_AUTO_RELOAD_ENABLED=${EMBEDDER_AUTO_RELOAD_ENABLED:-true}
+      - EMBEDDER_AUTO_RELOAD_RSS_KB_THRESHOLD=${EMBEDDER_AUTO_RELOAD_RSS_KB_THRESHOLD:-1200000}
+      - EMBEDDER_AUTO_RELOAD_CHECK_SEC=${EMBEDDER_AUTO_RELOAD_CHECK_SEC:-15}
+      - EMBEDDER_AUTO_RELOAD_HIGH_STREAK=${EMBEDDER_AUTO_RELOAD_HIGH_STREAK:-3}
+      - EMBEDDER_AUTO_RELOAD_MIN_INTERVAL_SEC=${EMBEDDER_AUTO_RELOAD_MIN_INTERVAL_SEC:-900}
+      - EMBEDDER_AUTO_RELOAD_WINDOW_SEC=${EMBEDDER_AUTO_RELOAD_WINDOW_SEC:-3600}
+      - EMBEDDER_AUTO_RELOAD_MAX_PER_WINDOW=${EMBEDDER_AUTO_RELOAD_MAX_PER_WINDOW:-2}
+      - EMBEDDER_AUTO_RELOAD_MAX_ACTIVE_REQUESTS=${EMBEDDER_AUTO_RELOAD_MAX_ACTIVE_REQUESTS:-2}
+      - EMBEDDER_AUTO_RELOAD_MAX_QUEUE_DEPTH=${EMBEDDER_AUTO_RELOAD_MAX_QUEUE_DEPTH:-0}
+      # Cloud Sync (optional - uncomment to enable)
+      # - CLOUD_SYNC_ENABLED=true
+      # - CLOUD_SYNC_BUCKET=my-memories
+      # - CLOUD_SYNC_REGION=us-east-1
+      # - CLOUD_SYNC_PREFIX=memories/
+      # - CLOUD_SYNC_ACCESS_KEY=AKIA...
+      # - CLOUD_SYNC_SECRET_KEY=...
+      # - CLOUD_SYNC_ENDPOINT=  # Optional: for MinIO, B2, etc.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import sys,urllib.request; sys.exit(0 if 200 <= urllib.request.urlopen('http://localhost:8000/health', timeout=3).getcode() < 400 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  qdrant-storage:
+  memories-data:

--- a/integrations/QUICKSTART-LLM.md
+++ b/integrations/QUICKSTART-LLM.md
@@ -20,21 +20,25 @@ Before starting, verify:
 
 ```bash
 # 1. Memories service is running
-curl -s http://localhost:8900/health | jq .
+curl -s http://localhost:8900/health
 
 # 2. Hook env file (installer writes this)
 grep -E '^(MEMORIES_URL|MEMORIES_API_KEY)=' ~/.config/memories/env 2>/dev/null || echo "No hook env file yet (installer will create it)"
 
-# 3. jq is installed
-jq --version
-
-# 4. Node/npm available for MCP server
-node --version && npm --version
+# 3. Node/npm available (for npx)
+node --version
 ```
 
-If the service isn't running:
+If the service isn't running, start it — no clone required:
+
 ```bash
-cd ~/projects/memories  # or wherever the repo lives
+curl -fsSL https://raw.githubusercontent.com/divyekant/memories/main/docker-compose.standalone.yml -o docker-compose.yml
+docker compose up -d
+```
+
+Or if you have the repo cloned:
+```bash
+cd ~/projects/memories
 docker compose up -d memories
 ```
 
@@ -45,16 +49,17 @@ docker compose up -d memories
 ### Option A: Run the Installer (Recommended)
 
 ```bash
-cd ~/projects/memories
-./integrations/claude-code/install.sh
+npx memories-mcp install --claude
 ```
 
 The installer will:
 1. Check Memories service health
-2. Ask which extraction provider to use (Anthropic, OpenAI, ChatGPT Subscription, Ollama, or skip)
+2. Ask which extraction provider to use (Anthropic, OpenAI, Ollama, or skip)
 3. Copy hook scripts to `~/.claude/hooks/memory/`
 4. Merge hook configuration into `~/.claude/settings.json`
-5. Write env files (`~/.config/memories/env` for hooks, repo `.env` for extraction)
+5. Write `~/.config/memories/env` with `MEMORIES_URL` and extraction vars
+
+No clone required. No `jq` or `curl` dependencies.
 
 ### Option B: Manual Setup
 
@@ -76,10 +81,11 @@ MEMORIES_API_KEY="your-api-key-here"  # optional if API auth is disabled
 EOF
 ```
 
-**Step 2b: Configure extraction provider in repo `.env`**
+**Step 2b: Configure extraction provider**
+
+Add to `~/.config/memories/env` (also set these in your docker-compose environment or `.env` so the service picks them up):
 
 ```bash
-cat >> ~/projects/memories/.env <<'EOF'
 # Choose one provider (or omit all for retrieval-only mode)
 EXTRACT_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-...
@@ -89,7 +95,6 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # EXTRACT_PROVIDER=ollama
 # OLLAMA_URL=http://localhost:11434
-EOF
 ```
 
 **Step 3: Add hooks to Claude Code settings**
@@ -171,12 +176,11 @@ Cursor supports full automatic memory via its **Third-party skills** feature, wh
 ### Step 1: Run the installer
 
 ```bash
-cd ~/projects/memories
-./integrations/claude-code/install.sh --cursor
+npx memories-mcp install --cursor
 ```
 
 This copies hook scripts to `~/.claude/hooks/memory/` and merges hook config into `~/.claude/settings.json`.
-It also writes Cursor MCP config at `~/.cursor/mcp.json` so tool calls work alongside hooks.
+It also writes Cursor MCP config at `~/.cursor/mcp.json` using `npx memories-mcp` so no local path is needed.
 
 ### Step 2: Enable Third-party skills in Cursor
 
@@ -194,8 +198,8 @@ If you prefer MCP-only manual config, add this to `~/.cursor/mcp.json`:
 {
   "mcpServers": {
     "memories": {
-      "command": "node",
-      "args": ["/path/to/memories/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["-y", "memories-mcp"],
       "env": {
         "MEMORIES_URL": "http://localhost:8900",
         "MEMORIES_API_KEY": "your-api-key-here"
@@ -217,25 +221,37 @@ Codex uses:
 ### Option A: Run the installer (recommended)
 
 ```bash
-cd ~/projects/memories
-cd mcp-server && npm install && cd ..
-./integrations/claude-code/install.sh --codex
+npx memories-mcp install --codex
 ```
 
 The installer will:
 1. Install memory hook scripts to `~/.codex/hooks/memory/`
 2. Merge the 5 Codex hook events into `~/.codex/settings.json`
-3. Add MCP server config for `memories` to `~/.codex/config.toml` when missing
+3. Add MCP server config for `memories` to `~/.codex/config.toml` using `npx memories-mcp`
 4. Add default `developer_instructions` (if not already set) to bias `memory_search` usage
 
 The hooks load `MEMORIES_URL` / `MEMORIES_API_KEY` from `~/.config/memories/env` (or `MEMORIES_ENV_FILE` override).
 Default scoped prefixes are `codex/{project},learning/{project},wip/{project}` for retrieval and `codex/{project}` for extraction.
 For scoped API keys, override them with `MEMORIES_SOURCE_PREFIXES` and `MEMORIES_EXTRACT_SOURCE`.
 
+No clone required. No `jq` or `curl` dependencies.
+
 ### Option B: Manual setup
 
 **Step 1: Install hook scripts**
 
+```bash
+# Option: use npx to get hook scripts from the package
+node -e "
+const src = require('path').join(require.resolve('memories-mcp'), '..', 'hooks');
+require('fs').mkdirSync(process.env.HOME + '/.codex/hooks/memory', {recursive:true});
+require('child_process').execSync('cp -r ' + src + '/. ' + process.env.HOME + '/.codex/hooks/memory/');
+console.log('Done');
+"
+chmod +x ~/.codex/hooks/memory/*.sh
+```
+
+Or if you have the repo cloned:
 ```bash
 mkdir -p ~/.codex/hooks/memory
 cp ~/projects/memories/integrations/claude-code/hooks/memory-*.sh ~/.codex/hooks/memory/
@@ -299,8 +315,8 @@ If `~/.codex/settings.json` already has hooks, merge these entries instead of re
 
 ```toml
 [mcp_servers.memories]
-command = "node"
-args = ["/path/to/memories/mcp-server/index.js"]
+command = "npx"
+args = ["-y", "memories-mcp"]
 
 [mcp_servers.memories.env]
 MEMORIES_URL = "http://localhost:8900"
@@ -585,8 +601,16 @@ This enables strict add-only fallback writes (no AUDN update/delete behavior), i
 
 ### Remove all integrations
 
+The easiest way is to use the installer:
+
 ```bash
-# Remove Claude hooks
+npx memories-mcp uninstall
+```
+
+Or manually:
+
+```bash
+# Remove Claude/Cursor hooks
 rm -rf ~/.claude/hooks/memory/
 
 # Remove Codex hooks
@@ -598,9 +622,8 @@ rm -rf ~/.codex/hooks/memory/
 # - [mcp_servers.memories] section
 # - [mcp_servers.memories.env] section
 
-# Remove env vars from hook/repo env files
-# Edit ~/.config/memories/env and remove MEMORIES_URL/MEMORIES_API_KEY/MEMORIES_SOURCE_PREFIXES/MEMORIES_EXTRACT_SOURCE
-# Edit ~/projects/memories/.env and remove EXTRACT_PROVIDER/provider keys
+# Remove env vars from hook env file
+# Edit ~/.config/memories/env and remove MEMORIES_URL/MEMORIES_API_KEY/MEMORIES_SOURCE_PREFIXES/MEMORIES_EXTRACT_SOURCE/EXTRACT_PROVIDER/provider keys
 ```
 
 ---
@@ -627,9 +650,14 @@ echo '{"cwd": "/Users/you/project", "session_type": "startup"}' | bash ~/.codex/
 ### Extraction returning 501
 
 ```bash
-# Extraction is disabled. Set EXTRACT_PROVIDER:
-echo 'EXTRACT_PROVIDER=anthropic' >> ~/projects/memories/.env  # or openai, chatgpt-subscription, ollama
-# Then restart docker-compose and your Claude/Cursor/Codex session
+# Extraction is disabled. Set EXTRACT_PROVIDER in your docker-compose environment:
+# Add to your .env file next to docker-compose.yml (or pass via docker compose env):
+echo 'EXTRACT_PROVIDER=anthropic' >> .env   # or openai, chatgpt-subscription, ollama
+echo 'ANTHROPIC_API_KEY=sk-ant-...' >> .env
+docker compose up -d memories  # restart to pick up new env
+
+# Also add to ~/.config/memories/env so hook scripts know the provider:
+echo 'EXTRACT_PROVIDER=anthropic' >> ~/.config/memories/env
 ```
 
 ### Slow retrieval hooks

--- a/mcp-server/assets/openclaw-skill.md
+++ b/mcp-server/assets/openclaw-skill.md
@@ -1,0 +1,1001 @@
+---
+name: memories
+version: 2.2.0
+description: Use when recalling past decisions, project history, preferences, or learnings; storing new facts or insights; searching what was previously discussed or built. Provides persistent semantic memory across sessions via the Memories service.
+metadata:
+  clawdbot:
+    emoji: "🧠"
+    requires:
+      commands:
+        - curl
+        - jq
+---
+
+# Memories
+
+Local semantic memory using Memories vector search + BM25 hybrid retrieval (Docker service).
+
+## Features
+
+- **Fast**: <20ms semantic searches
+- **Hybrid**: BM25 keyword + Memories vector search (RRF fusion)
+- **Local**: 100% on-device, no external APIs
+- **Secure**: Localhost-only Docker service
+- **Backed up**: Automatic backups before operations
+- **Independent**: Survives OpenClaw upgrades
+- **CRUD**: Full create, read, update, delete support
+- **QMD Bridge**: Sync Memories into OpenClaw's native `memory_search` via QMD
+- **Graph search**: Related memories linked automatically, surfaced via `graph_weight` param
+- **Temporal search**: `since`/`until` date-range filters, `document_at` timestamps on memories
+- **Version tracking**: UPDATE archives old version with `supersedes` link, searchable with `include_archived`
+
+## Prerequisites
+
+- Docker service running: `docker ps | grep memories`
+- If not running: `cd /path/to/memories && docker compose up -d memories`
+
+### Making API key available to OpenClaw
+
+OpenClaw agents run inside the gateway process and do not automatically inherit shell env vars
+from `~/.config/memories/env` or your shell profile. Add Memories credentials to the gateway
+config so `$MEMORIES_API_KEY` and `$MEMORIES_URL` are available in skill exec calls:
+
+```bash
+openclaw config patch '{"env": {"vars": {"MEMORIES_URL": "http://localhost:8900", "MEMORIES_API_KEY": "your-key"}}}'
+```
+
+Or edit `~/.openclaw/openclaw.json` directly under `env.vars`, then restart the gateway.
+
+---
+
+## OpenClaw QMD Bridge Integration
+
+### The Problem
+
+OpenClaw's built-in `memory_search` tool only queries its native backends (built-in SQLite or QMD). Memories runs as a separate Docker service with its own vector index. Without a bridge, Memories content is invisible to `memory_search` — the agent must explicitly call Memories API functions to access it.
+
+### The Solution
+
+A sync script exports all Memories content as grouped markdown files into a directory that QMD indexes as a collection. This makes Memories content discoverable through OpenClaw's native `memory_search` alongside workspace files and session transcripts.
+
+For writes, the agent dual-writes: storing insights in both workspace markdown files (for QMD) and the Memories API (for the vector index). This keeps both systems in sync.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  OpenClaw memory_search (unified query)             │
+│  ├── memory files (MEMORY.md + memory/*.md)         │  ← QMD collection: memory
+│  ├── session transcripts                            │  ← QMD collection: sessions-<agentId>
+│  └── Memories content (synced)                      │  ← QMD collection: memories-<agentId>
+│           ↑                                         │
+│     sync script (daily)                             │
+│           ↑                                         │
+│     Memories API (localhost:8900)                    │
+└─────────────────────────────────────────────────────┘
+
+Writes:
+  Agent ──→ memory/YYYY-MM-DD.md  (QMD indexes directly)
+       └──→ POST /memory/add      (Memories API, synced to QMD via script)
+```
+
+### Setup: QMD Bridge Sync Script
+
+Create this script in your workspace (e.g. `scripts/sync-memories-to-qmd.sh`):
+
+```bash
+#!/bin/bash
+# Sync Memories → QMD collection for unified memory_search
+# Run daily via heartbeat or cron to keep QMD in sync with Memories.
+set -euo pipefail
+
+MEMORIES_API="${MEMORIES_API:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_ENV_FILE="${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+AGENT_ID="${OPENCLAW_AGENT_ID:-jack}"
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+EXPORT_DIR="$STATE_DIR/agents/$AGENT_ID/qmd/memories-export"
+COLLECTION="memories-$AGENT_ID"
+
+if [[ -f "$MEMORIES_ENV_FILE" ]]; then
+  set -a
+  source "$MEMORIES_ENV_FILE"
+  set +a
+fi
+
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+# Auth header (optional — only needed if MEMORIES_API_KEY is set)
+CURL_HEADERS=()
+if [[ -n "$MEMORIES_API_KEY" ]]; then
+  CURL_HEADERS+=(-H "X-API-Key: $MEMORIES_API_KEY")
+fi
+
+# Check API is up
+if ! curl -sf "${CURL_HEADERS[@]}" "$MEMORIES_API/health" >/dev/null 2>&1; then
+  echo "❌ Memories API not responding at $MEMORIES_API"
+  exit 1
+fi
+
+mkdir -p "$EXPORT_DIR"
+
+TOTAL=$(curl -sf "${CURL_HEADERS[@]}" "$MEMORIES_API/health" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total_memories',0))")
+echo "📦 Exporting $TOTAL memories from Memories..."
+
+# Export all memories and write as grouped markdown files
+python3 - "$MEMORIES_API" "$EXPORT_DIR" "$MEMORIES_API_KEY" << 'PYEOF'
+import json, os, re, sys, urllib.request
+
+api = sys.argv[1]
+export_dir = sys.argv[2]
+api_key = sys.argv[3] if len(sys.argv) > 3 else ""
+
+# Clean old exports
+for f in os.listdir(export_dir):
+    if f.endswith('.md'):
+        os.remove(os.path.join(export_dir, f))
+
+# Fetch all memories (paginated)
+memories = []
+offset = 0
+while True:
+    url = f"{api}/memories?offset={offset}&limit=100"
+    req = urllib.request.Request(url)
+    if api_key:
+        req.add_header("X-API-Key", api_key)
+    resp = urllib.request.urlopen(req)
+    data = json.loads(resp.read())
+    batch = data.get("memories", [])
+    memories.extend(batch)
+    if len(batch) < 100:
+        break
+    offset += 100
+
+# Group by top-level source folder
+folders = {}
+for m in memories:
+    source = m.get('source', 'uncategorized') or 'uncategorized'
+    folder = source.split('/')[0] if '/' in source else source
+    folder = re.sub(r'[^\w\-]', '_', folder)
+    folders.setdefault(folder, []).append(m)
+
+# Write one markdown file per folder
+count = 0
+for folder, mems in folders.items():
+    filepath = os.path.join(export_dir, f"{folder}.md")
+    with open(filepath, 'w') as f:
+        f.write(f"# Memories: {folder}\n\n")
+        f.write(f"> Auto-synced from Memories project\n")
+        f.write(f"> {len(mems)} entries\n\n")
+        for m in mems:
+            text = m.get('text', '').strip()
+            source = m.get('source', '')
+            ts = (m.get('timestamp') or '')[:10]
+            f.write(f"## [{source}] ({ts})\n\n{text}\n\n---\n\n")
+            count += 1
+
+print(f"✅ Exported {count} memories to {len(folders)} files")
+PYEOF
+
+# Create or update QMD collection
+if qmd collection list 2>/dev/null | grep -q "$COLLECTION"; then
+  echo "🔄 Updating QMD collection '$COLLECTION'..."
+  qmd update -c "$COLLECTION" 2>&1 | tail -3
+else
+  echo "📁 Creating QMD collection '$COLLECTION'..."
+  qmd collection add --name "$COLLECTION" "$EXPORT_DIR" '**/*.md' 2>&1
+  qmd update -c "$COLLECTION" 2>&1 | tail -3
+fi
+
+# Embed new chunks (required for vector search)
+echo "🧠 Embedding new chunks..."
+qmd embed 2>&1 | tail -3
+
+echo "✅ Sync complete — Memories are now searchable via memory_search"
+```
+
+**Make it executable:**
+```bash
+chmod +x scripts/sync-memories-to-qmd.sh
+```
+
+**Run the initial sync:**
+```bash
+bash scripts/sync-memories-to-qmd.sh
+```
+
+### Setup: QMD Session Collection Fix
+
+OpenClaw expects session transcript collections named `sessions-<agentId>` (e.g. `sessions-jack`). If QMD created the collection with a different name, `memory_search` will fail to find session transcripts and fall back to the built-in search (which doesn't cover sessions).
+
+**Check if sessions are indexed:**
+```bash
+openclaw memory status
+# Look for: sessions · 0/N files · 0 chunks
+# If 0 chunks but N files exist, the collection name is wrong.
+```
+
+**Fix the naming:**
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"  # Change to your agent ID
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+# Remove old collection and recreate with correct name
+qmd collection remove sessions 2>/dev/null
+qmd collection remove "sessions-$AGENT_ID" 2>/dev/null
+qmd collection add --name "sessions-$AGENT_ID" \
+  "$STATE_DIR/agents/$AGENT_ID/qmd/sessions" '**/*.md'
+```
+
+### Setup: SQLite WAL Lock Recovery
+
+If QMD searches fail with `SQLITE_BUSY_RECOVERY`, a stale WAL lock file is blocking access. This can happen after a crash or ungraceful shutdown.
+
+**Fix:**
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+sqlite3 "$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache/qmd/index.sqlite" \
+  "PRAGMA wal_checkpoint(TRUNCATE);"
+```
+
+### Scheduling the Sync
+
+**Option A: OpenClaw Heartbeat (recommended)**
+
+Add to your `HEARTBEAT.md`:
+```markdown
+### Memories → QMD Sync (daily)
+- Run `bash ~/your-workspace/scripts/sync-memories-to-qmd.sh`
+- Keeps `memory_search` results unified across all memory sources
+```
+
+**Option B: OpenClaw Cron Job**
+
+```bash
+# Via OpenClaw cron — runs daily at 6 AM
+openclaw cron add --name "Memories QMD Sync" \
+  --schedule '{"kind":"cron","expr":"0 6 * * *"}' \
+  --payload '{"kind":"systemEvent","text":"Run: bash ~/your-workspace/scripts/sync-memories-to-qmd.sh"}' \
+  --session-target main
+```
+
+**Option C: System Crontab**
+
+```bash
+crontab -e
+# Add:
+0 6 * * * /path/to/workspace/scripts/sync-memories-to-qmd.sh >> /tmp/memories-sync.log 2>&1
+```
+
+### Dual-Write Pattern (Recommended)
+
+To keep Memories and QMD in sync without waiting for the daily sync, the agent should dual-write: store significant insights in both systems simultaneously.
+
+**When the agent learns something worth remembering:**
+
+1. **Write to daily markdown file** (QMD picks this up automatically):
+   ```
+   Append to memory/YYYY-MM-DD.md
+   ```
+
+2. **Write to Memories API** (immediate vector search availability):
+   ```bash
+   memory_add_memories "The insight or learning" "source/topic"
+   ```
+
+3. **The daily sync script** acts as a safety net — if either write was missed, the sync reconciles by exporting all Memories content to QMD.
+
+**When to dual-write:**
+- Decisions with rationale
+- User preferences (explicit or observed)
+- Bug root causes and fixes
+- Architectural patterns
+- Lessons learned from failures
+
+**When NOT to dual-write (markdown only is fine):**
+- Routine task completions
+- Temporary context
+- Raw session logs
+
+---
+
+## Commands
+
+### Search Memories (Hybrid)
+
+```bash
+function memory_search_memories() {
+    local query="$1"
+    local k="${2:-5}"
+    local threshold="${3:-0.0}"
+    local hybrid="${4:-true}"
+    local api="${MEMORIES_URL:-http://localhost:8900}"
+
+    local payload
+    payload=$(jq -n \
+        --arg q "$query" \
+        --argjson k "$k" \
+        --argjson t "$threshold" \
+        --argjson h "$hybrid" \
+        '{query: $q, k: $k, threshold: $t, hybrid: $h}')
+
+    curl -s -X POST "$api/search" \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq -r '.results[] | "\(.similarity // .rrf_score | tonumber | . * 100 | floor)% | \(.source): \(.text[:200])"'
+}
+
+# Usage
+memory_search_memories "database preferences"
+memory_search_memories "database preferences" 3       # Top 3 results
+memory_search_memories "database preferences" 5 0.7   # Min 70% similarity
+memory_search_memories "exact keyword match" 5 0 true # Hybrid mode (default)
+```
+
+### Add New Memory
+
+```bash
+function memory_add_memories() {
+    local text="$1"
+    local source="$2"
+    local dedup="${3:-true}"
+
+    local payload
+    payload=$(jq -n \
+        --arg t "$text" \
+        --arg s "$source" \
+        --argjson d "$dedup" \
+        '{text: $t, source: $s, deduplicate: $d}')
+
+    curl -s -X POST http://localhost:8900/memory/add \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq -r '.message'
+}
+
+# Usage
+memory_add_memories "Prefer Brave Search API" "technical.md:180"
+memory_add_memories "New fact" "source.md" true  # auto-dedup (default)
+```
+
+### Check if Novel
+
+```bash
+function memory_is_novel() {
+    local text="$1"
+    local threshold="${2:-0.88}"
+
+    local payload
+    payload=$(jq -n \
+        --arg t "$text" \
+        --argjson th "$threshold" \
+        '{text: $t, threshold: $th}')
+
+    local result
+    result=$(curl -s -X POST http://localhost:8900/memory/is-novel \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload")
+
+    local is_novel
+    is_novel=$(echo "$result" | jq -r '.is_novel')
+
+    if [[ "$is_novel" == "true" ]]; then
+        echo "✅ Novel (no similar memories found)"
+        return 0
+    else
+        echo "❌ Not novel - similar memory exists:"
+        echo "$result" | jq -r '.most_similar | "\(.similarity | tonumber | . * 100 | floor)% | \(.source): \(.text[:200])"'
+        return 1
+    fi
+}
+
+# Usage
+memory_is_novel "New preference to check"
+```
+
+### Delete Memory
+
+```bash
+function memory_delete_memories() {
+    local id="$1"
+    curl -s -X DELETE "http://localhost:8900/memory/$id" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+    | jq -r '.deleted_text // .detail'
+}
+
+# Usage
+memory_delete_memories 42
+```
+
+### Delete by Source
+
+```bash
+function memory_delete_source_memories() {
+    local pattern="$1"
+
+    local payload
+    payload=$(jq -n --arg p "$pattern" '{source_pattern: $p}')
+
+    curl -s -X POST http://localhost:8900/memory/delete-by-source \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq -r '"Deleted \(.deleted_count) memories"'
+}
+
+# Usage
+memory_delete_source_memories "credentials"
+memory_delete_source_memories "old-file.md"
+```
+
+### Bulk Delete by Source Prefix
+
+```bash
+function memory_delete_by_prefix() {
+    local prefix="$1"
+
+    curl -s -X DELETE "http://localhost:8900/memories?source=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$prefix'))")" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+    | jq -r '"Deleted \(.count) memories"'
+}
+
+# Usage
+memory_delete_by_prefix "team/old-project/"
+memory_delete_by_prefix "deprecated"
+```
+
+### Count Memories by Source
+
+```bash
+function memory_count_memories() {
+    local source="${1:-}"
+
+    local url="http://localhost:8900/memories/count"
+    if [[ -n "$source" ]]; then
+        url="${url}?source=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$source'))")"
+    fi
+
+    curl -s "$url" -H "X-API-Key: $MEMORIES_API_KEY" | jq -r '.count'
+}
+
+# Usage
+memory_count_memories                 # Total count
+memory_count_memories "team/project"  # Count for a source prefix
+```
+
+### Browse Memories
+
+```bash
+function memory_list_memories() {
+    local offset="${1:-0}"
+    local limit="${2:-20}"
+    local source="${3:-}"
+
+    local url="http://localhost:8900/memories?offset=$offset&limit=$limit"
+    if [[ -n "$source" ]]; then
+        url="${url}&source=$source"
+    fi
+
+    curl -s "$url" -H "X-API-Key: $MEMORIES_API_KEY" | jq -r '.memories[] | "[\(.id)] \(.source): \(.text[:120])"'
+}
+
+# Usage
+memory_list_memories             # First 20
+memory_list_memories 20 10       # Next 10
+memory_list_memories 0 50 "lang" # Filter by source
+```
+
+### Rebuild Index
+
+```bash
+function memory_rebuild_index() {
+    echo "🔄 Rebuilding Memories index from workspace files..."
+
+    curl -s -X POST http://localhost:8900/index/build \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d '{}' \
+    | jq -r '"✅ \(.message)\n   Files: \(.files_processed)\n   Memories: \(.memories_added)\n   Backup: \(.backup_location)"'
+}
+
+# Usage
+memory_rebuild_index
+```
+
+### Deduplicate
+
+```bash
+function memory_dedup_memories() {
+    local dry_run="${1:-true}"
+    local threshold="${2:-0.90}"
+
+    local payload
+    payload=$(jq -n \
+        --argjson d "$dry_run" \
+        --argjson t "$threshold" \
+        '{dry_run: $d, threshold: $t}')
+
+    curl -s -X POST http://localhost:8900/memory/deduplicate \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq '.'
+}
+
+# Usage
+memory_dedup_memories true       # Dry run (preview)
+memory_dedup_memories false      # Actually remove duplicates
+memory_dedup_memories true 0.85  # Lower threshold = more aggressive
+```
+
+### View Stats
+
+```bash
+function memory_stats() {
+    curl -s http://localhost:8900/stats -H "X-API-Key: $MEMORIES_API_KEY" | jq '
+        "📊 Memories Stats",
+        "━━━━━━━━━━━━━━━━━━━━━━",
+        "Total memories: \(.total_memories)",
+        "Dimensions: \(.dimension)",
+        "Model: \(.model)",
+        "Index size: \(.index_size_bytes / 1024 | floor)KB",
+        "Backups: \(.backup_count)",
+        "Last updated: \(.last_updated // "never")"
+    ' -r
+}
+
+# Usage
+memory_stats
+```
+
+### List Backups
+
+```bash
+function memory_backups() {
+    curl -s http://localhost:8900/backups -H "X-API-Key: $MEMORIES_API_KEY" \
+    | jq -r '.backups[] | "\(.name)"'
+}
+
+# Usage
+memory_backups
+```
+
+### Create Manual Backup
+
+```bash
+function memory_backup() {
+    local prefix="${1:-manual}"
+
+    curl -s -X POST "http://localhost:8900/backup?prefix=$prefix" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+    | jq -r '"✅ \(.message)\n   Location: \(.backup_path)"'
+}
+
+# Usage
+memory_backup
+memory_backup "before_upgrade"
+```
+
+### Restore from Backup
+
+```bash
+function memory_restore() {
+    local backup_name="$1"
+
+    local payload
+    payload=$(jq -n --arg b "$backup_name" '{backup_name: $b}')
+
+    curl -s -X POST http://localhost:8900/restore \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq -r '"✅ \(.message)\n   Memories: \(.total_memories)"'
+}
+
+# Usage
+memory_backups                           # List available
+memory_restore "manual_20260213_120000"  # Restore specific backup
+```
+
+### Health Check
+
+```bash
+function memory_health() {
+    curl -s http://localhost:8900/health -H "X-API-Key: $MEMORIES_API_KEY" | jq '
+        if .status == "ok" then
+            "✅ Memories: HEALTHY (v\(.version // "?"))\n   Memories: \(.total_memories)\n   Model: \(.model)"
+        else
+            "❌ Memories: UNHEALTHY"
+        end
+    ' -r
+}
+
+# Usage
+memory_health
+```
+
+### Recall Project Context (Auto)
+
+Call this at the start of any task to load relevant project memories:
+
+```bash
+function memory_recall_memories() {
+    local project="${1:-$(basename "$PWD")}"
+    local api="${MEMORIES_URL:-http://localhost:8900}"
+    local scoped_threshold="${2:-0.35}"
+    local fallback_threshold="${3:-0.50}"
+
+    run_search() {
+        local query="$1"
+        local prefix="${2:-}"
+        local k="$3"
+        local threshold="$4"
+
+        local payload
+        if [[ -n "$prefix" ]]; then
+            payload=$(jq -n \
+                --arg q "$query" \
+                --arg p "$prefix" \
+                --argjson k "$k" \
+                --argjson t "$threshold" \
+                '{query: $q, source_prefix: $p, k: $k, hybrid: true, threshold: $t}')
+        else
+            payload=$(jq -n \
+                --arg q "$query" \
+                --argjson k "$k" \
+                --argjson t "$threshold" \
+                '{query: $q, k: $k, hybrid: true, threshold: $t}')
+        fi
+
+        curl -s -X POST "$api/search" \
+            -H "Content-Type: application/json" \
+            -H "X-API-Key: $MEMORIES_API_KEY" \
+            -d "$payload"
+    }
+
+    local merged
+    merged=$(
+        {
+            run_search "project $project architecture decisions conventions" "openclaw/$project" 4 "$scoped_threshold"
+            run_search "project $project fixes gotchas learnings workarounds" "learning/$project" 3 "$scoped_threshold"
+            run_search "project $project deferred work blockers open threads" "wip/$project" 2 "$scoped_threshold"
+        } | jq -sr '[.[].results[]?] | unique_by(.id) | sort_by(-(.similarity // .rrf_score // 0)) | .[0:8]'
+    )
+
+    local results
+    results=$(printf '%s' "$merged" | jq -r 'map("- [\(.source)] \(.text)") | join("\n")')
+
+    if [[ -z "$results" || "$results" == "null" ]]; then
+        results=$(
+            run_search "project $project conventions decisions patterns" "" 6 "$fallback_threshold" \
+            | jq -r '[.results[]?] | .[0:8] | map("- [\(.source)] \(.text)") | join("\n")'
+        )
+    fi
+
+    if [[ -n "$results" && "$results" != "null" ]]; then
+        echo "## Relevant Memories"
+        echo ""
+        echo "$results"
+    else
+        echo "No relevant memories found for project: $project"
+    fi
+}
+
+# Usage — call at the start of every task
+memory_recall_memories
+memory_recall_memories "my-project" 10
+```
+
+### Extract Facts from Conversation (Auto)
+
+Call this after completing significant tasks to store new learnings.
+
+The extraction API returns **categorized facts** rather than plain strings. Each extracted fact includes a category that indicates its type:
+
+| Category | What it captures | Examples |
+|---|---|---|
+| `DECISION` | Architectural choices, *why* over *what* | "Chose Drizzle over Prisma for type-safe SQL and simpler migrations" |
+| `LEARNING` | Bug fixes, gotchas, hard-won knowledge | "vite.config.ts needs `optimizeDeps.exclude: ['fsevents']` on macOS or HMR hangs" |
+| `DETAIL` | File paths, conventions, concrete facts | "Auth middleware lives in src/middleware/auth.ts, runs before all /api routes" |
+
+**Durability test**: The extractor applies a 30-day durability test -- only facts that would still be useful in 30 days get extracted. Ephemeral details (temporary debug flags, one-off error messages) are filtered out.
+
+**Source-awareness**: The `source` field is used to derive the project name. For example, `source: "openclaw/my-project"` tells the extractor this conversation is about `my-project`, so it can contextualize facts appropriately.
+
+```bash
+function memory_extract_memories() {
+    local messages="$1"
+    local source="${2:-openclaw/$(basename "$PWD")}"
+    local context="${3:-stop}"
+    local api="${MEMORIES_URL:-http://localhost:8900}"
+
+    local payload
+    payload=$(jq -n \
+        --arg m "$messages" \
+        --arg s "$source" \
+        --arg c "$context" \
+        '{messages: $m, source: $s, context: $c}')
+
+    curl -s -X POST "$api/memory/extract" \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $MEMORIES_API_KEY" \
+        -d "$payload" \
+    | jq '.'
+}
+
+# Usage — call after completing tasks
+memory_extract_memories "User: use drizzle\nAssistant: Good choice, switching from Prisma"
+memory_extract_memories "conversation text" "openclaw/my-project" "session_end"
+
+# Example response (new categorized format):
+# {
+#   "extracted": [
+#     {"category": "DECISION", "text": "Chose Drizzle over Prisma for type-safe SQL and simpler migrations"},
+#     {"category": "DETAIL",   "text": "ORM config lives in drizzle.config.ts at project root"}
+#   ],
+#   "stored": 2,
+#   "duplicates_skipped": 0
+# }
+```
+
+## OpenClaw Smart Recall Protocol
+
+### When to recall proactively
+
+- Any question about past decisions, project history, or architecture
+- Starting work on a project you have touched before
+- When the user says `remember`, `last time`, `we decided`, or `what was`
+- Before making a significant technical decision
+
+### How to recall
+
+Use a multi-prefix strategy instead of one generic search:
+
+- `openclaw/{project}` for architecture, decisions, and conventions
+- `learning/{project}` for fixes, gotchas, and workarounds
+- `wip/{project}` for deferred work, blockers, and open threads
+
+The built-in `memory_recall_memories` helper already does this merge + dedup flow. If you need
+manual control, use these tuned searches directly:
+
+```bash
+PROJECT="my-project"
+
+# Decisions + architecture
+curl -s -X POST "$MEMORIES_URL/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
+  -d "{\"query\":\"project $PROJECT architecture decisions conventions\",\"source_prefix\":\"openclaw/$PROJECT\",\"k\":4,\"hybrid\":true,\"threshold\":0.35}"
+
+# Learnings + fixes
+curl -s -X POST "$MEMORIES_URL/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
+  -d "{\"query\":\"project $PROJECT fixes gotchas learnings workarounds\",\"source_prefix\":\"learning/$PROJECT\",\"k\":3,\"hybrid\":true,\"threshold\":0.35}"
+
+# Deferred work + blockers
+curl -s -X POST "$MEMORIES_URL/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $MEMORIES_API_KEY" \
+  -d "{\"query\":\"project $PROJECT deferred work blockers open threads\",\"source_prefix\":\"wip/$PROJECT\",\"k\":2,\"hybrid\":true,\"threshold\":0.35}"
+```
+
+If all scoped searches return empty, fall back to a broader global search around `0.5`.
+
+### Memory Playbook
+
+- Surface deferred or blocked work explicitly before the rest of the context
+- Carry boundary conditions forward, especially `until`, `unless`, and `because`
+- Do not ask the user to reconfirm a remembered decision before acting on it
+- For short follow-up prompts, include recent conversation context in the search query
+
+## Automatic Lifecycle (OpenClaw)
+
+OpenClaw has no hook system, so the agent must call the memory helpers explicitly.
+
+**At the start of any non-trivial task:**
+```bash
+memory_recall_memories "<topic or project name>"
+```
+
+**After completing significant work (decision made, bug fixed, feature built):**
+```bash
+memory_extract_memories "<summary of what happened>" "openclaw/<project>" "stop"
+```
+
+**During heartbeats or maintenance cycles:**
+- Search for stale, contradicted, or deferred memories that need cleanup
+- Sync the QMD bridge with `bash ~/your-workspace/scripts/sync-memories-to-qmd.sh`
+
+Add these reminders to `HEARTBEAT.md` if you want them enforced on every heartbeat cycle.
+
+## Memory Discipline — Three Responsibilities
+
+Your job is the judgment layer: deciding what's worth storing, when to search, and when
+to trigger lifecycle operations. This complements automatic extraction (heartbeats) with
+active judgment about what matters.
+
+### 1. Read — Proactive Recall
+
+Search memories BEFORE asking questions or proposing solutions — not just when explicitly
+asked to remember something.
+
+**When to search:**
+- When the user asks about a feature that might have prior context
+- Before asking a clarifying question about project architecture or preferences
+- When picking up work in a domain where deferred tasks might exist
+- Before attempting something that might have failed before
+
+```bash
+memory_search_memories "notifications webhooks" 5
+memory_search_memories "deferred TODO revisit wip" 5
+memory_search_memories "failure fix gotcha postgres" 5
+```
+
+Surface relevant findings to the user before proposing solutions. If nothing found,
+proceed normally but mention you checked.
+
+### 2. Write — Capture at Natural Breakpoints
+
+**Hard triggers (always store):**
+- User explicitly says "remember this", "store this", "save for later"
+
+**Soft triggers (use judgment):**
+- Architectural decision made (including implicit ones like "I use Postgres")
+- Work deferred ("we'll do this later", "parking this")
+- Non-obvious fix or gotcha discovered
+- Phase transition (design → implementation, debug → fix)
+- Multiple decisions in one message
+
+**What NOT to store:** session status, generic knowledge, debugging steps (only the fix),
+information stale by next session.
+
+#### Choosing the Right Tool
+
+| Situation | Tool | Cost | Why |
+|-----------|------|------|-----|
+| Single clear new fact | `memory_add_memories` | Free | Simple, fast |
+| User says "remember X" (novel) | `memory_add_memories` | Free | Direct intent |
+| Decision changed/reversed | `memory_extract_memories` | ~$0.001 | AUDN updates old memory |
+| Deferred work completed | `memory_extract_memories` | ~$0.001 | AUDN deletes wip entry |
+| Rich conversation, multiple facts | `memory_extract_memories` | ~$0.001 | Server splits and handles each |
+| Contradiction found during recall | `memory_extract_memories` | ~$0.001 | AUDN resolves conflicts |
+| Learning superseded by better fix | `memory_extract_memories` | ~$0.001 | AUDN updates old learning |
+
+**When using `memory_add_memories`:** check `memory_is_novel` first.
+**When using `memory_extract_memories`:** skip novelty check — AUDN handles it internally.
+
+### 3. Maintain — Lifecycle Management
+
+Most maintenance happens automatically through `memory_extract_memories`'s AUDN cycle,
+but some situations need direct action:
+
+- User says "forget this" → `memory_search_memories` to find it, then `memory_delete_memories` by ID
+- Project cleanup → `memory_delete_by_prefix "openclaw/old-project/"`
+- Stale deferred work → `memory_delete_by_prefix "wip/project"`
+
+### Source Prefix Convention
+
+| Prefix | Use for |
+|--------|---------|
+| `openclaw/{project}` | Code decisions, architecture choices |
+| `learning/{project}` | Patterns, gotchas, fixes |
+| `wip/{project}` | Deferred work, open threads |
+
+---
+
+## Typical Workflows
+
+### Task Start — Recall Context
+```bash
+memory_recall_memories
+memory_search_memories "your query" 5
+```
+
+### After Task Completion — Extract Learnings
+```bash
+memory_extract_memories "summary of conversation or key decisions"
+```
+
+### Store Single Fact
+```bash
+memory_add_memories "New preference or fact" "openclaw/my-project"
+```
+
+### Weekly Maintenance
+```bash
+memory_rebuild_index
+memory_dedup_memories true   # Preview
+memory_dedup_memories false  # Execute
+```
+
+### Before OpenClaw Upgrade
+```bash
+memory_backup "before_openclaw_upgrade_$(date +%Y%m%d)"
+```
+
+## Integration with Self-Learning
+
+During heartbeats, I can:
+
+1. **Extract new learnings** using `memory_extract_memories` (preferred — sends conversation to the extract endpoint which categorizes facts as DECISION/LEARNING/DETAIL, applies a 30-day durability filter, and handles AUDN lifecycle in one call)
+2. **Manual alternative**: Check novelty with `memory_is_novel`, then add if novel with `memory_add_memories` (auto-dedup enabled)
+3. **Recall context** at task start with `memory_recall_memories`
+4. **Auto-backup** handled by service
+5. **Sync to QMD** via `sync-memories-to-qmd.sh` (daily, keeps `memory_search` unified)
+
+## Troubleshooting
+
+### Service not responding
+```bash
+docker ps | grep memories
+docker logs -f memories
+cd /path/to/memories && docker compose restart memories
+```
+
+### Empty search results
+```bash
+memory_stats
+memory_rebuild_index
+```
+
+### Restore from backup
+```bash
+memory_backups
+memory_restore "BACKUP_NAME"
+```
+
+### QMD bridge not finding Memories content
+```bash
+# Re-run the sync
+bash scripts/sync-memories-to-qmd.sh
+
+# Verify the collection exists
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+qmd collection list | grep memories
+
+# Check OpenClaw sees it
+openclaw memory status
+```
+
+### QMD SQLite lock errors (SQLITE_BUSY_RECOVERY)
+```bash
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+sqlite3 "$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache/qmd/index.sqlite" \
+  "PRAGMA wal_checkpoint(TRUNCATE);"
+```
+
+### Session transcripts not searchable (0 chunks)
+```bash
+# Fix collection naming — OpenClaw expects sessions-<agentId>
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+AGENT_ID="jack"
+export XDG_CONFIG_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-config"
+export XDG_CACHE_HOME="$STATE_DIR/agents/$AGENT_ID/qmd/xdg-cache"
+
+qmd collection remove sessions 2>/dev/null
+qmd collection remove "sessions-$AGENT_ID" 2>/dev/null
+qmd collection add --name "sessions-$AGENT_ID" \
+  "$STATE_DIR/agents/$AGENT_ID/qmd/sessions" '**/*.md'
+```
+
+## Notes
+
+- Service runs independently of OpenClaw
+- Survives OpenClaw restarts/upgrades
+- Backups created automatically before destructive ops
+- Read-only access to workspace files
+- All data persists in the bind-mounted `./data/` directory (configured in `docker-compose.yml`)
+- API docs available at http://localhost:8900/docs
+- QMD bridge sync is one-way (Memories → QMD); writes to QMD markdown don't flow back to Memories

--- a/mcp-server/hooks/_lib.sh
+++ b/mcp-server/hooks/_lib.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Shared utilities for Memories hooks
+
+MEMORIES_LOG="${MEMORIES_LOG:-$HOME/.config/memories/hook.log}"
+
+_log() {
+  local level="$1" msg="$2"
+  local logdir
+  logdir=$(dirname "$MEMORIES_LOG")
+  [ -d "$logdir" ] || mkdir -p "$logdir" 2>/dev/null || return 0
+  echo "$(date -u +%FT%TZ) [$level] [${MEMORIES_HOOK_NAME:-unknown}] $msg" >> "$MEMORIES_LOG" 2>/dev/null
+}
+
+_log_info() { _log "INFO" "$1"; }
+_log_error() { _log "ERROR" "$1"; }
+_log_warn() { _log "WARN" "$1"; }
+
+# Rotate log if over 1000 lines (called from SessionStart only)
+_rotate_log() {
+  if [ -f "$MEMORIES_LOG" ] && [ "$(wc -l < "$MEMORIES_LOG" 2>/dev/null)" -gt 1000 ]; then
+    tail -500 "$MEMORIES_LOG" > "$MEMORIES_LOG.tmp" && mv "$MEMORIES_LOG.tmp" "$MEMORIES_LOG"
+    _log_info "Log rotated (kept last 500 lines)"
+  fi
+}
+
+_memory_client_prefix() {
+  local hook_dir
+  hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  case "$hook_dir" in
+    *"/.codex/"*)
+      printf 'codex'
+      ;;
+    *)
+      printf 'claude-code'
+      ;;
+  esac
+}
+
+_default_source_prefixes() {
+  local client_prefix
+  client_prefix="$(_memory_client_prefix)"
+  printf '%s/{project},learning/{project},wip/{project}' "$client_prefix"
+}
+
+_default_extract_source() {
+  local client_prefix
+  client_prefix="$(_memory_client_prefix)"
+  printf '%s/{project}' "$client_prefix"
+}
+
+# Health check — returns 0 if service is reachable
+_health_check() {
+  local url="${MEMORIES_URL:-http://localhost:8900}"
+  curl -sf --max-time 2 "$url/health" >/dev/null 2>&1
+}
+
+# -- Multi-Backend Config --------------------------------------------------
+
+_BACKENDS_CACHE=""
+
+# Pure-shell YAML parser for backends.yaml — handles the simple flat format only.
+# Supports: backends.<name>.url, backends.<name>.api_key, backends.<name>.scenario,
+# and routing.<op>: [name1, name2].
+_parse_backends_yaml() {
+  local file="$1"
+  local current_section="" current_name="" backends_json="[]" routing_json="{}"
+  local url="" api_key="" scenario="" _routing_current_key=""
+
+  _flush_backend() {
+    if [ -n "$current_name" ] && [ -n "$url" ]; then
+      # Resolve ${VAR} references in api_key
+      local resolved_key="$api_key"
+      local env_var
+      env_var=$(printf '%s' "$api_key" | sed -n 's/.*\${\([A-Za-z_][A-Za-z0-9_]*\)}.*/\1/p')
+      if [ -n "$env_var" ]; then
+        resolved_key="${!env_var:-$api_key}"
+      fi
+      # Resolve ${VAR} references in url
+      local resolved_url="$url"
+      local url_env_var
+      url_env_var=$(printf '%s' "$url" | sed -n 's/.*\${\([A-Za-z_][A-Za-z0-9_]*\)}.*/\1/p')
+      if [ -n "$url_env_var" ]; then
+        resolved_url="${!url_env_var:-$url}"
+      fi
+      backends_json=$(printf '%s' "$backends_json" | jq -c --arg n "$current_name" \
+        --arg u "$resolved_url" --arg k "$resolved_key" --arg s "$scenario" \
+        '. + [{name: $n, url: $u, api_key: $k, scenario: $s}]')
+    fi
+    url="" api_key="" scenario="" current_name=""
+  }
+
+  while IFS= read -r line; do
+    # Skip comments and blank lines
+    case "$line" in
+      '#'*|'') continue ;;
+    esac
+
+    # Top-level sections
+    if printf '%s' "$line" | grep -qE '^backends:'; then
+      current_section="backends"
+      continue
+    fi
+    if printf '%s' "$line" | grep -qE '^routing:'; then
+      current_section="routing"
+      continue
+    fi
+
+    if [ "$current_section" = "backends" ]; then
+      # Backend name line (2-space indent, no further indent)
+      if printf '%s' "$line" | grep -qE '^  [a-zA-Z_][a-zA-Z0-9_-]*:'; then
+        _flush_backend
+        current_name=$(printf '%s' "$line" | sed 's/^ *//;s/:.*//')
+      fi
+      # Properties (4-space indent)
+      if printf '%s' "$line" | grep -qE '^    url:'; then
+        url=$(printf '%s' "$line" | sed 's/^    url: *//;s/^ *//;s/ *$//')
+      fi
+      if printf '%s' "$line" | grep -qE '^    api_key:'; then
+        api_key=$(printf '%s' "$line" | sed 's/^    api_key: *//;s/^ *//;s/ *$//')
+      fi
+      if printf '%s' "$line" | grep -qE '^    scenario:'; then
+        scenario=$(printf '%s' "$line" | sed 's/^    scenario: *//;s/^ *//;s/ *$//')
+      fi
+    fi
+
+    if [ "$current_section" = "routing" ]; then
+      # Routing supports two YAML formats:
+      #   Inline:  search: [alpha, beta]
+      #   Block:   search:\n  - alpha\n  - beta
+      if printf '%s' "$line" | grep -qE '^ +- '; then
+        # Block list item — append to current routing key (2 or 4 space indent)
+        local item
+        item=$(printf '%s' "$line" | sed 's/^ *- *//;s/ *$//')
+        if [ -n "$item" ] && [ -n "$_routing_current_key" ]; then
+          routing_json=$(printf '%s' "$routing_json" | jq -c --arg k "$_routing_current_key" --arg v "$item" \
+            '.[$k] = ((.[$k] // []) + [$v])')
+        fi
+      elif printf '%s' "$line" | grep -qE '^  [a-z_]+:'; then
+        local rkey rval
+        rkey=$(printf '%s' "$line" | sed 's/^ *//;s/:.*//')
+        rval=$(printf '%s' "$line" | sed 's/^[^:]*: *//;s/^ *//;s/ *$//')
+        _routing_current_key="$rkey"
+        if [ -n "$rval" ]; then
+          # Inline format: search: [alpha, beta]
+          rval=$(printf '%s' "$rval" | sed 's/\[//;s/\]//;s/,/ /g')
+          local rarray="[]"
+          for item in $rval; do
+            item=$(printf '%s' "$item" | sed 's/^ *//;s/ *$//')
+            [ -n "$item" ] && rarray=$(printf '%s' "$rarray" | jq -c --arg v "$item" '. + [$v]')
+          done
+          routing_json=$(printf '%s' "$routing_json" | jq -c --arg k "$rkey" --argjson v "$rarray" '. + {($k): $v}')
+        fi
+      fi
+    fi
+  done < "$file"
+  _flush_backend
+
+  jq -nc --argjson b "$backends_json" --argjson r "$routing_json" '{backends: $b, routing: $r}'
+}
+
+_load_backends() {
+  # Return cached if already loaded
+  if [ -n "$_BACKENDS_CACHE" ]; then
+    echo "$_BACKENDS_CACHE" | jq -c '.backends'
+    return 0
+  fi
+
+  local config_file="${MEMORIES_BACKENDS_FILE:-}"
+
+  # Resolution: explicit env → project → global → env var fallback
+  if [ -z "$config_file" ]; then
+    if [ -f "${CWD:-}/.memories/backends.yaml" ] 2>/dev/null; then
+      config_file="$CWD/.memories/backends.yaml"
+    elif [ -f "$HOME/.config/memories/backends.yaml" ]; then
+      config_file="$HOME/.config/memories/backends.yaml"
+    fi
+  fi
+
+  if [ -n "$config_file" ] && [ -f "$config_file" ]; then
+    # Parse YAML → JSON.  Try Node.js + js-yaml first (best fidelity),
+    # fall back to a pure-shell parser for the simple backends.yaml format.
+    local raw=""
+
+    if command -v node >/dev/null 2>&1; then
+      # Try to find js-yaml via multiple search paths.  Installed hooks live at
+      # ~/.claude/hooks/memory/ (not in the repo), so the relative path to
+      # mcp-server/node_modules won't resolve.  We search:
+      #   1. Plain require (works if cwd is inside the repo)
+      #   2. Relative to this script's directory (works in-repo)
+      #   3. Well-known global config location
+      local hooks_dir
+      hooks_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+      local search_paths="${hooks_dir}/../../../mcp-server/node_modules:${hooks_dir}/../../mcp-server/node_modules"
+      search_paths="${search_paths}:$HOME/.config/memories/mcp-server/node_modules"
+
+      raw=$(NODE_PATH="${search_paths}:${NODE_PATH:-}" node -e "
+try {
+  const yaml = require('js-yaml');
+  const fs = require('fs');
+  const data = yaml.load(fs.readFileSync('${config_file}', 'utf8'));
+  const interp = (v) => { const m = (v||'').match(/\\\$\{(\w+)\}/); return m ? (process.env[m[1]] || v) : v; };
+  const backends = Object.entries(data.backends || {}).map(([name, cfg]) => {
+    return { name, url: interp(cfg.url || ''), api_key: interp(cfg.api_key || ''), scenario: cfg.scenario || '' };
+  });
+  console.log(JSON.stringify({ backends, routing: data.routing || {} }));
+} catch(e) {
+  process.exit(1);
+}
+" 2>/dev/null) || raw=""
+    fi
+
+    # Fallback: pure-shell parser for the simple flat YAML format
+    # (handles: backends.<name>.url, .api_key, .scenario; routing.<op>: [list])
+    if [ -z "$raw" ]; then
+      raw=$(_parse_backends_yaml "$config_file")
+    fi
+    _BACKENDS_CACHE="$raw"
+    # Output just the backends array for simple callers
+    echo "$raw" | jq -c '.backends'
+  else
+    # Fallback to env vars — single backend
+    local url="${MEMORIES_URL:-http://localhost:8900}"
+    local key="${MEMORIES_API_KEY:-}"
+    _BACKENDS_CACHE=$(jq -nc --arg url "$url" --arg key "$key" \
+      '{backends: [{name: "default", url: $url, api_key: $key, scenario: ""}], routing: {}}')
+    echo "$_BACKENDS_CACHE" | jq -c '.backends'
+  fi
+}
+
+_get_backends_for_op() {
+  local op="$1"  # search | extract | add | feedback
+
+  # Load full config (with routing)
+  _load_backends > /dev/null  # populate cache
+  local config="$_BACKENDS_CACHE"
+  local backends
+  backends=$(echo "$config" | jq -c '.backends')
+  local routing
+  routing=$(echo "$config" | jq -c '.routing // {}')
+  local count
+  count=$(echo "$backends" | jq 'length')
+
+  # Single backend — always that one
+  if [ "$count" -eq 1 ]; then
+    echo "$backends"
+    return 0
+  fi
+
+  # Check explicit routing first
+  local explicit
+  explicit=$(echo "$routing" | jq -c --arg op "$op" '.[$op] // empty')
+  if [ -n "$explicit" ] && [ "$explicit" != "null" ]; then
+    # Filter backends by name
+    echo "$backends" | jq -c --argjson names "$explicit" \
+      '[.[] | select(.name as $n | $names | index($n))]'
+    return 0
+  fi
+
+  # Scenario-based routing
+  case "$op" in
+    search)
+      # All backends for search
+      echo "$backends"
+      ;;
+    extract)
+      # dev or personal backends only
+      echo "$backends" | jq -c '[.[] | select(.scenario == "dev" or .scenario == "personal")]'
+      ;;
+    add)
+      # All writable backends (dev + prod, personal + shared)
+      echo "$backends"
+      ;;
+    feedback)
+      # dev or personal only
+      echo "$backends" | jq -c '[.[] | select(.scenario == "dev" or .scenario == "personal")]'
+      ;;
+    *)
+      # Default: primary (first)
+      echo "$backends" | jq -c '[.[0]]'
+      ;;
+  esac
+}
+
+# -- Multi-Backend Search --------------------------------------------------
+
+_search_memories_multi() {
+  local query="$1"
+  local prefix="${2:-}"
+  local limit="${3:-5}"
+  local threshold="${4:-0.4}"
+
+  local backends
+  backends=$(_get_backends_for_op "search")
+  local count
+  count=$(echo "$backends" | jq 'length')
+
+  local body
+  if [ -n "$prefix" ]; then
+    body=$(jq -nc --arg q "$query" --arg p "$prefix" --argjson k "$limit" --argjson t "$threshold" \
+      '{query: $q, source_prefix: $p, k: $k, hybrid: true, threshold: $t}')
+  else
+    body=$(jq -nc --arg q "$query" --argjson k "$limit" --argjson t "$threshold" \
+      '{query: $q, k: $k, hybrid: true, threshold: $t}')
+  fi
+
+  if [ "$count" -le 1 ]; then
+    # Single backend — direct call (backward compat, no overhead)
+    local url key
+    url=$(echo "$backends" | jq -r '.[0].url')
+    key=$(echo "$backends" | jq -r '.[0].api_key')
+    curl -sf --max-time 4 -X POST "$url/search" \
+      -H "Content-Type: application/json" \
+      -H "X-API-Key: $key" \
+      -d "$body" 2>/dev/null || echo '{"results":[],"count":0}'
+    return
+  fi
+
+  # Multi-backend: parallel fan-out with background subshells
+  # Use process substitution (< <(...)) so the while loop runs in the current
+  # shell and `wait` can actually collect the background jobs.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local i=0
+  while read -r backend; do
+    local url key name
+    url=$(echo "$backend" | jq -r '.url')
+    key=$(echo "$backend" | jq -r '.api_key')
+    name=$(echo "$backend" | jq -r '.name')
+    (
+      result=$(curl -sf --max-time 4 -X POST "$url/search" \
+        -H "Content-Type: application/json" \
+        -H "X-API-Key: $key" \
+        -d "$body" 2>/dev/null)
+      if [ -n "$result" ]; then
+        # Tag results with _backend
+        echo "$result" | jq -c --arg b "$name" '.results[] | . + {_backend: $b}' > "$tmpdir/result_${name}.jsonl"
+      fi
+    ) &
+    i=$((i + 1))
+  done < <(echo "$backends" | jq -c '.[]')
+  wait
+
+  # Merge results: sort by score, dedup keeping highest-scoring duplicate,
+  # then re-sort to guarantee global score ordering after dedup.
+  cat "$tmpdir"/result_*.jsonl 2>/dev/null | jq -s '
+    sort_by(-(.similarity // .rrf_score // 0))
+    | unique_by(.text)
+    | sort_by(-(.similarity // .rrf_score // 0))
+  ' | jq -c '{results: ., count: length}'
+
+  rm -rf "$tmpdir"
+}
+
+# -- Multi-Backend Extract -------------------------------------------------
+
+_extract_multi() {
+  local messages="$1"
+  local source="$2"
+  local context="${3:-stop}"
+
+  local backends
+  backends=$(_get_backends_for_op "extract")
+  # Pass current timestamp as document_at for temporal reasoning
+  local doc_at
+  doc_at=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+  local body
+  body=$(jq -nc --arg m "$messages" --arg s "$source" --arg c "$context" --arg d "$doc_at" \
+    '{messages: $m, source: $s, context: $c, document_at: $d}')
+
+  echo "$backends" | jq -c '.[]' | while read -r backend; do
+    local url key name
+    url=$(echo "$backend" | jq -r '.url')
+    key=$(echo "$backend" | jq -r '.api_key')
+    name=$(echo "$backend" | jq -r '.name')
+    curl -sf --max-time 30 -X POST "$url/memory/extract" \
+      -H "Content-Type: application/json" \
+      -H "X-API-Key: $key" \
+      -d "$body" > /dev/null 2>&1 || _log_error "Extract failed for backend $name"
+  done
+}

--- a/mcp-server/hooks/hooks.json
+++ b/mcp-server/hooks/hooks.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-recall.sh",
+        "timeout": 5
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-query.sh",
+        "timeout": 3
+      }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-extract.sh",
+        "timeout": 30
+      }]
+    }],
+    "PreCompact": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-flush.sh",
+        "timeout": 30
+      }]
+    }],
+    "PostCompact": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-rehydrate.sh",
+        "timeout": 5
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "mcp__memories__",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-observe.sh",
+        "timeout": 1
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": "Write|Edit",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-guard.sh",
+        "timeout": 1
+      }]
+    }],
+    "SubagentStop": [{
+      "matcher": "Plan|Explore",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-subagent-capture.sh",
+        "timeout": 30
+      }]
+    }],
+    "ConfigChange": [{
+      "matcher": "user_settings",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-config-guard.sh",
+        "timeout": 2
+      }]
+    }],
+    "SessionEnd": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "${MEMORIES_HOOKS_DIR:-~/.claude/hooks/memory}/memory-commit.sh",
+        "timeout": 30
+      }]
+    }]
+  }
+}

--- a/mcp-server/hooks/memory-commit.sh
+++ b/mcp-server/hooks/memory-commit.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# memory-commit.sh — SessionEnd hook
+# Final extraction pass before session terminates.
+# CC SessionEnd provides: session_id, transcript_path, cwd, reason
+# Reads recent human+assistant text messages from JSONL transcript.
+
+MEMORIES_HOOK_NAME="memory-commit"
+
+set -euo pipefail
+
+# Load from dedicated env file
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_extract_source() { echo 'claude-code/{project}'; }
+fi
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+
+# Configurable thresholds (Task 1.2)
+TAIL_LINES="${MEMORIES_COMMIT_TAIL_LINES:-500}"
+MSG_PAIRS="${MEMORIES_COMMIT_MSG_PAIRS:-10}"
+MSG_CAP="${MEMORIES_COMMIT_MSG_CAP:-8000}"
+
+INPUT=$(cat)
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
+PROJECT=$(basename "$CWD")
+
+# Expand tilde if present
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+# Build extraction source — supports {project} placeholder (Task 1.3)
+_DEFAULT_SRC="$(_default_extract_source)"
+_EXTRACT_SRC="${MEMORIES_EXTRACT_SOURCE:-$_DEFAULT_SRC}"
+SOURCE="${_EXTRACT_SRC//\{project\}/$PROJECT}"
+
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# Extract text-bearing messages from transcript JSONL.
+# Transcript format: each line is {type, message: {role, content}, ...}
+# Content can be string or array of {type: "text"|"tool_use"|"tool_result", text: "..."}
+# We only want entries that have actual text, skipping pure tool_use/tool_result entries.
+MESSAGES=$(tail -"$TAIL_LINES" "$TRANSCRIPT_PATH" 2>/dev/null | jq -sr --argjson pairs "$MSG_PAIRS" '
+  [
+    .[]
+    | select(.type == "user" or .type == "assistant")
+    | {
+        role: .type,
+        text: (
+          if .message.content | type == "string" then
+            .message.content
+          elif .message.content | type == "array" then
+            [.message.content[] | select(.type == "text") | .text] | join(" ")
+          else
+            ""
+          end
+        )
+      }
+    | select(.text != "" and (.text | length) > 10)
+  ]
+  | .[-$pairs:]
+  | map(.role + ": " + (.text | .[0:2000]))
+  | join("\n\n")
+' 2>/dev/null) || { _log_warn "Transcript parse failed for $TRANSCRIPT_PATH"; true; }
+
+if [ -z "$MESSAGES" ] || [ "$MESSAGES" = "null" ]; then
+  exit 0
+fi
+
+# Truncate to MSG_CAP chars to stay within extraction limits
+MESSAGES="${MESSAGES:0:$MSG_CAP}"
+
+# Signal keyword pre-filter — skip extraction if no signals detected
+SIGNAL_KEYWORDS="${MEMORIES_SIGNAL_KEYWORDS:-decide|decision|chose|bug|fix|remember|architecture|convention|pattern|learning|mistake}"
+if [ -n "$SIGNAL_KEYWORDS" ] && [ -n "$MESSAGES" ] && ! echo "$MESSAGES" | grep -qiE "$SIGNAL_KEYWORDS"; then
+  exit 0
+fi
+
+_log_info "Commit-extracting from $PROJECT (${#MESSAGES} chars, source=$SOURCE)"
+
+_extract_multi "$MESSAGES" "$SOURCE" "session_end"

--- a/mcp-server/hooks/memory-config-guard.sh
+++ b/mcp-server/hooks/memory-config-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MEMORIES_HOOK_NAME="memory-config-guard"
+
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+fi
+
+INPUT=$(cat)
+
+# Only check user_settings changes
+SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
+case "$SOURCE" in
+  user_settings) ;;
+  *) exit 0 ;;
+esac
+
+SETTINGS_FILE="$HOME/.claude/settings.json"
+[ -f "$SETTINGS_FILE" ] || { _log_warn "Settings file not found"; exit 0; }
+
+# Check if memory hooks are still configured
+MISSING=""
+for hook in "memory-recall" "memory-query" "memory-extract"; do
+  if ! grep -q "$hook" "$SETTINGS_FILE" 2>/dev/null; then
+    MISSING="$MISSING $hook"
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  _log_warn "Memory hooks may be missing from settings:$MISSING"
+  jq -n --arg ctx "## Memories Configuration Warning
+
+Some memory hooks appear to be missing from settings.json:$MISSING
+This may affect memory recall and extraction. Run the Memories installer to restore them." \
+    '{"additionalContext": $ctx}'
+fi
+
+exit 0

--- a/mcp-server/hooks/memory-extract.sh
+++ b/mcp-server/hooks/memory-extract.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# memory-extract.sh — Stop hook
+# Extracts facts from the last user+assistant message pair.
+# CC Stop hook provides: session_id, transcript_path, cwd, last_assistant_message
+
+MEMORIES_HOOK_NAME="memory-extract"
+
+set -euo pipefail
+
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_extract_source() { echo 'claude-code/{project}'; }
+fi
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+
+# Configurable thresholds (Task 1.2)
+TAIL_LINES="${MEMORIES_EXTRACT_TAIL_LINES:-200}"
+MSG_PAIRS="${MEMORIES_EXTRACT_MSG_PAIRS:-2}"
+MSG_CAP="${MEMORIES_EXTRACT_MSG_CAP:-4000}"
+
+INPUT=$(cat)
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
+PROJECT=$(basename "$CWD")
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+
+# Expand tilde if present
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+# Build extraction source — supports {project} placeholder (Task 1.3)
+_DEFAULT_SRC="$(_default_extract_source)"
+_EXTRACT_SRC="${MEMORIES_EXTRACT_SOURCE:-$_DEFAULT_SRC}"
+SOURCE="${_EXTRACT_SRC//\{project\}/$PROJECT}"
+
+MESSAGES=""
+
+# Try to read last user+assistant pair from transcript for decision context
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  MESSAGES=$(tail -"$TAIL_LINES" "$TRANSCRIPT_PATH" 2>/dev/null | jq -sr --argjson pairs "$MSG_PAIRS" '
+    [
+      .[]
+      | select(.type == "user" or .type == "assistant")
+      | {
+          role: .type,
+          text: (
+            if .message.content | type == "string" then
+              .message.content
+            elif .message.content | type == "array" then
+              [.message.content[] | select(.type == "text") | .text] | join(" ")
+            else
+              ""
+            end
+          )
+        }
+      | select(.text != "" and (.text | length) > 10)
+    ]
+    | .[-$pairs:]
+    | map(.role + ": " + (.text | .[0:2000]))
+    | join("\n\n")
+  ' 2>/dev/null) || { _log_warn "Transcript parse failed for $TRANSCRIPT_PATH"; true; }
+fi
+
+# Fallback to last_assistant_message if transcript read failed
+if [ -z "$MESSAGES" ] || [ "$MESSAGES" = "null" ]; then
+  MESSAGES=$(echo "$INPUT" | jq -r '.last_assistant_message // empty')
+fi
+
+if [ -z "$MESSAGES" ]; then
+  exit 0
+fi
+
+# Cap at MSG_CAP chars (one pair is plenty for the Stop hook)
+MESSAGES="${MESSAGES:0:$MSG_CAP}"
+
+# Signal keyword pre-filter — skip extraction if no signals detected
+SIGNAL_KEYWORDS="${MEMORIES_SIGNAL_KEYWORDS:-decide|decision|chose|bug|fix|remember|architecture|convention|pattern|learning|mistake}"
+if [ -n "$SIGNAL_KEYWORDS" ] && [ -n "$MESSAGES" ] && ! echo "$MESSAGES" | grep -qiE "$SIGNAL_KEYWORDS"; then
+  exit 0
+fi
+
+_log_info "Extracting from $PROJECT (${#MESSAGES} chars, source=$SOURCE)"
+
+_extract_multi "$MESSAGES" "$SOURCE" "stop"

--- a/mcp-server/hooks/memory-flush.sh
+++ b/mcp-server/hooks/memory-flush.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# memory-flush.sh — PreCompact hook
+# Aggressive extraction before context compaction.
+# CC PreCompact provides: session_id, transcript_path, cwd
+# Reads recent messages from JSONL transcript before they're compacted away.
+
+MEMORIES_HOOK_NAME="memory-flush"
+
+set -euo pipefail
+
+# Load from dedicated env file
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_extract_source() { echo 'claude-code/{project}'; }
+fi
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+
+# Configurable thresholds (Task 1.2)
+TAIL_LINES="${MEMORIES_FLUSH_TAIL_LINES:-1000}"
+MSG_PAIRS="${MEMORIES_FLUSH_MSG_PAIRS:-20}"
+MSG_CAP="${MEMORIES_FLUSH_MSG_CAP:-12000}"
+
+INPUT=$(cat)
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
+PROJECT=$(basename "$CWD")
+
+# Expand tilde if present
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+# Build extraction source — supports {project} placeholder (Task 1.3)
+_DEFAULT_SRC="$(_default_extract_source)"
+_EXTRACT_SRC="${MEMORIES_EXTRACT_SOURCE:-$_DEFAULT_SRC}"
+SOURCE="${_EXTRACT_SRC//\{project\}/$PROJECT}"
+
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# Pre-compact: read aggressively to capture context about to be lost
+MESSAGES=$(tail -"$TAIL_LINES" "$TRANSCRIPT_PATH" 2>/dev/null | jq -sr --argjson pairs "$MSG_PAIRS" '
+  [
+    .[]
+    | select(.type == "user" or .type == "assistant")
+    | {
+        role: .type,
+        text: (
+          if .message.content | type == "string" then
+            .message.content
+          elif .message.content | type == "array" then
+            [.message.content[] | select(.type == "text") | .text] | join(" ")
+          else
+            ""
+          end
+        )
+      }
+    | select(.text != "" and (.text | length) > 10)
+  ]
+  | .[-$pairs:]
+  | map(.role + ": " + (.text | .[0:2000]))
+  | join("\n\n")
+' 2>/dev/null) || { _log_warn "Transcript parse failed for $TRANSCRIPT_PATH"; true; }
+
+if [ -z "$MESSAGES" ] || [ "$MESSAGES" = "null" ]; then
+  exit 0
+fi
+
+# Truncate to MSG_CAP chars (more aggressive for pre-compact)
+MESSAGES="${MESSAGES:0:$MSG_CAP}"
+
+_log_info "Flush-extracting from $PROJECT (${#MESSAGES} chars, source=$SOURCE)"
+
+_extract_multi "$MESSAGES" "$SOURCE" "pre_compact"

--- a/mcp-server/hooks/memory-guard.sh
+++ b/mcp-server/hooks/memory-guard.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# memory-guard.sh — PreToolUse hook for Write|Edit
+# Blocks writes to MEMORY.md files, which are managed by Memories MCP sync.
+
+set -euo pipefail
+
+MEMORIES_HOOK_NAME="memory-guard"
+
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+fi
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Block writes to MEMORY.md (auto-memory managed by Memories MCP sync)
+if [[ "$FILE" == */MEMORY.md ]] || [[ "$FILE" == */memory/MEMORY.md ]]; then
+  _log_warn "Blocked write to MEMORY.md: $FILE"
+  echo "MEMORY.md is managed by Memories MCP sync. Use memory_add or memory_extract instead of writing directly." >&2
+  exit 2
+fi
+
+exit 0

--- a/mcp-server/hooks/memory-observe.sh
+++ b/mcp-server/hooks/memory-observe.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# memory-observe.sh — PostToolUse observer
+# Fire-and-forget logger that tracks when memory MCP tools are called.
+# No additionalContext output.
+
+set -euo pipefail
+
+MEMORIES_HOOK_NAME="memory-observe"
+
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+fi
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+USAGE_LOG="${MEMORIES_TOOL_LOG:-$HOME/.config/memories/tool-usage.log}"
+
+# Append tool usage
+echo "$(date -u +%FT%TZ) $TOOL" >> "$USAGE_LOG" 2>/dev/null || true
+
+_log_info "Tool used: $TOOL"
+exit 0

--- a/mcp-server/hooks/memory-query.sh
+++ b/mcp-server/hooks/memory-query.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# memory-query.sh — UserPromptSubmit hook
+# Searches Memories for memories relevant to the current prompt.
+# Prefers project-scoped sources first and uses recent transcript context
+# so short follow-up prompts still retrieve the right memories.
+# Sync hook: blocks until done, injects additionalContext.
+
+MEMORIES_HOOK_NAME="memory-query"
+
+set -euo pipefail
+
+# Load from dedicated env file — avoids requiring shell profile changes
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_source_prefixes() { echo 'claude-code/{project},learning/{project},wip/{project}'; }
+fi
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_SOURCE_PREFIXES="${MEMORIES_SOURCE_PREFIXES:-}"
+if [ -z "$MEMORIES_SOURCE_PREFIXES" ]; then
+  MEMORIES_SOURCE_PREFIXES="$(_default_source_prefixes)"
+fi
+MEMORIES_QUERY_SCOPED_K="${MEMORIES_QUERY_SCOPED_K:-3}"
+MEMORIES_QUERY_FALLBACK_K="${MEMORIES_QUERY_FALLBACK_K:-5}"
+MEMORIES_QUERY_SCOPED_THRESHOLD="${MEMORIES_QUERY_SCOPED_THRESHOLD:-0.35}"
+MEMORIES_QUERY_FALLBACK_THRESHOLD="${MEMORIES_QUERY_FALLBACK_THRESHOLD:-0.55}"
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // .workspace_roots[0] // .workspaceRoots[0] // empty')
+PROJECT=$(basename "${CWD:-}")
+if [ -z "$PROJECT" ] || [ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ]; then
+  PROJECT=""
+fi
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // .transcriptPath // empty')
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+build_response_hint() {
+  local prompt_lower="$1"
+  local hints_file="$(dirname "$0")/response-hints.json"
+
+  [ -f "$hints_file" ] || return
+
+  # Check each pattern
+  local match template
+  while IFS= read -r line; do
+    match=$(echo "$line" | jq -r '.match')
+    template=$(echo "$line" | jq -r '.template')
+    if echo "$prompt_lower" | grep -qiE "$match"; then
+      echo "$template"
+      return
+    fi
+  done < <(jq -c '.patterns[]' "$hints_file")
+}
+
+extract_recent_context() {
+  local transcript_path="$1"
+  if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
+    return 0
+  fi
+
+  tail -200 "$transcript_path" 2>/dev/null | jq -sr '
+    [
+      .[]
+      | select(.type == "user" or .type == "assistant")
+      | {
+          role: .type,
+          text: (
+            if .message.content | type == "string" then
+              .message.content
+            elif .message.content | type == "array" then
+              [.message.content[] | select(.type == "text") | .text] | join(" ")
+            else
+              ""
+            end
+          )
+        }
+      | select(.text != "" and (.text | length) > 4)
+    ]
+    | .[-4:]
+    | map(
+        (if .role == "user" then "User: " else "Assistant: " end) +
+        (
+          .text
+          | gsub("[\\r\\n]+"; " ")
+          | gsub("\\s+"; " ")
+          | .[0:500]
+        )
+      )
+    | join("\n")
+  ' 2>/dev/null || { _log_warn "Transcript context extraction failed"; true; }
+}
+
+search_memories() {
+  _search_memories_multi "$@"
+}
+
+CONTEXT=$(extract_recent_context "$TRANSCRIPT_PATH")
+PROMPT_LOWER=$(printf '%s' "$PROMPT" | tr '[:upper:]' '[:lower:]')
+
+# File context extraction — grep recent transcript for Read/Edit/Write tool calls
+FILE_CONTEXT=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  ACTIVE_FILES=$(tail -20 "$TRANSCRIPT_PATH" 2>/dev/null | { grep -oE '(Read|Edit|Write) /[^ "]+' || true; } | awk '{print $2}' | xargs -I{} basename {} 2>/dev/null | sort -u | head -5 | tr '\n' ', ' | sed 's/,$//')
+  [ -n "$ACTIVE_FILES" ] && FILE_CONTEXT="Files: $ACTIVE_FILES"
+fi
+
+# Key term extraction — pull identifiers from the prompt
+KEY_TERMS=$(echo "$PROMPT" | { grep -oE '[A-Z][a-z]+([A-Z][a-z]+)+|[a-z]+_[a-z_]+|[A-Z_]{3,}' 2>/dev/null || true; } | sort -u | head -10 | tr '\n' ', ' | sed 's/,$//')
+[ -n "$KEY_TERMS" ] && KEY_TERMS="Terms: $KEY_TERMS"
+
+# Intent-based prefix biasing
+INTENT_PREFIXES=""
+case "$PROMPT_LOWER" in
+  fix*|debug*|error*|bug*|broken*|crash*)
+    INTENT_PREFIXES="learning/$PROJECT bug-fix/$PROJECT" ;;
+  how*|setup*|configure*|install*)
+    INTENT_PREFIXES="decision/$PROJECT learning/$PROJECT" ;;
+esac
+
+# Enrich the search query with extracted context
+ENRICHED=""
+[ -n "$FILE_CONTEXT" ] && ENRICHED="$FILE_CONTEXT\n"
+[ -n "$KEY_TERMS" ] && ENRICHED="${ENRICHED}$KEY_TERMS\n"
+
+QUERY_TEXT="$PROMPT"
+if [ -n "$CONTEXT" ]; then
+  if [ -n "$PROMPT" ]; then
+    QUERY_TEXT=$(printf '%s%s\nProject: %s\nRecent conversation:\n%s\nCurrent prompt: %s' "$ENRICHED" "" "${PROJECT:-unknown}" "$CONTEXT" "$PROMPT")
+  else
+    QUERY_TEXT=$(printf '%s%s\nProject: %s\nRecent conversation:\n%s' "$ENRICHED" "" "${PROJECT:-unknown}" "$CONTEXT")
+  fi
+elif [ -n "$ENRICHED" ]; then
+  QUERY_TEXT=$(printf '%s\n%s' "$ENRICHED" "$PROMPT")
+fi
+
+# Skip only if we have neither a meaningful prompt nor recent conversation.
+if [ -z "$QUERY_TEXT" ] || { [ ${#PROMPT} -lt 20 ] && [ -z "$CONTEXT" ]; }; then
+  exit 0
+fi
+
+RAW_RESPONSES=""
+if [ -n "$PROJECT" ]; then
+  IFS=',' read -r -a prefix_templates <<< "$MEMORIES_SOURCE_PREFIXES"
+  for raw_prefix in "${prefix_templates[@]}"; do
+    raw_prefix=$(echo "$raw_prefix" | xargs)
+    [ -z "$raw_prefix" ] && continue
+
+    prefix=$(printf '%s' "$raw_prefix" | sed "s/{project}/$PROJECT/g")
+    response=$(search_memories "$QUERY_TEXT" "$prefix" "$MEMORIES_QUERY_SCOPED_K" "$MEMORIES_QUERY_SCOPED_THRESHOLD")
+    if [ -n "$response" ]; then
+      RAW_RESPONSES=$(printf '%s\n%s' "$RAW_RESPONSES" "$response")
+    fi
+  done
+
+  # Search intent-based prefixes if present (in addition to standard prefixes)
+  if [ -n "$INTENT_PREFIXES" ]; then
+    for intent_prefix in $INTENT_PREFIXES; do
+      response=$(search_memories "$QUERY_TEXT" "$intent_prefix" "$MEMORIES_QUERY_SCOPED_K" "$MEMORIES_QUERY_SCOPED_THRESHOLD")
+      if [ -n "$response" ]; then
+        RAW_RESPONSES=$(printf '%s\n%s' "$RAW_RESPONSES" "$response")
+      fi
+    done
+  fi
+fi
+
+RESULTS_JSON=$(printf '%s\n' "$RAW_RESPONSES" | jq -sr '
+  map(select(type == "object") | (.results // []))
+  | add
+  | unique_by(.id)
+  | sort_by(-(.similarity // .rrf_score // 0))
+  | .[0:6]
+' 2>/dev/null) || RESULTS_JSON="[]"
+
+if [ "$RESULTS_JSON" = "[]" ]; then
+  FALLBACK_RESPONSE=$(search_memories "$QUERY_TEXT" "" "$MEMORIES_QUERY_FALLBACK_K" "$MEMORIES_QUERY_FALLBACK_THRESHOLD")
+  RESULTS_JSON=$(printf '%s' "$FALLBACK_RESPONSE" | jq -c '.results // []' 2>/dev/null) || RESULTS_JSON="[]"
+fi
+
+RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- [\(.source)] \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
+
+if [ -z "$RESULTS" ] || [ "$RESULTS" = "null" ]; then
+  exit 0
+fi
+
+_log_info "Query returned $(printf '%s' "$RESULTS_JSON" | jq -r 'length' 2>/dev/null || echo 0) results for prompt (${#PROMPT} chars)"
+
+RESPONSE_HINT=$(build_response_hint "$PROMPT_LOWER")
+
+jq -n --arg memories "$RESULTS" --arg response_hint "$RESPONSE_HINT" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: (
+      "## Retrieved Memories\n" + $memories +
+      (if ($response_hint | length) > 0 then "\n\n" + $response_hint else "" end)
+    )
+  }
+}'

--- a/mcp-server/hooks/memory-recall.sh
+++ b/mcp-server/hooks/memory-recall.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# memory-recall.sh — SessionStart hook
+# Loads project-relevant memories into Claude Code context.
+# Also hydrates auto-memory MEMORY.md with synced memories from MCP,
+# so the most important memories are always in context (200-line cap).
+# Sync hook: blocks until done, injects additionalContext.
+
+MEMORIES_HOOK_NAME="memory-recall"
+
+set -euo pipefail
+
+# Load from dedicated env file — avoids requiring shell profile changes
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_source_prefixes() { echo 'claude-code/{project},learning/{project},wip/{project}'; }
+fi
+
+# Rotate log on session start
+_rotate_log
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+MEMORIES_SOURCE_PREFIXES="${MEMORIES_SOURCE_PREFIXES:-}"
+if [ -z "$MEMORIES_SOURCE_PREFIXES" ]; then
+  MEMORIES_SOURCE_PREFIXES="$(_default_source_prefixes)"
+fi
+MEMORIES_RECALL_SCOPED_THRESHOLD="${MEMORIES_RECALL_SCOPED_THRESHOLD:-0.35}"
+MEMORIES_RECALL_FALLBACK_THRESHOLD="${MEMORIES_RECALL_FALLBACK_THRESHOLD:-0.55}"
+
+# Configurable recall limit (Task 1.2)
+RECALL_LIMIT="${MEMORIES_RECALL_LIMIT:-8}"
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // .workspace_roots[0] // empty')
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+
+PROJECT=$(basename "$CWD")
+if [ -z "$PROJECT" ] || [ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ]; then
+  exit 0
+fi
+
+_log_info "Session start for project=$PROJECT cwd=$CWD"
+
+# Health check — warn if service unreachable
+HEALTH_WARNING=""
+if ! _health_check; then
+  _log_warn "Service unreachable at $MEMORIES_URL"
+  HEALTH_WARNING=$(cat <<HWEOF
+## Memories Service Warning
+
+Memories service is not reachable at $MEMORIES_URL. Memory recall and extraction are unavailable this session. Check that the service is running.
+HWEOF
+)
+fi
+
+search_memories() {
+  _search_memories_multi "$@"
+}
+
+query_for_prefix() {
+  local prefix="$1"
+  case "$prefix" in
+    claude-code/*|codex/*)
+      printf 'project %s architecture decisions conventions patterns' "$PROJECT"
+      ;;
+    learning/*)
+      printf 'project %s fixes gotchas learnings workarounds' "$PROJECT"
+      ;;
+    wip/*)
+      printf 'project %s deferred work blockers open threads revisit later' "$PROJECT"
+      ;;
+    *)
+      printf 'project %s conventions decisions patterns' "$PROJECT"
+      ;;
+  esac
+}
+
+RAW_RESPONSES=""
+SCOPED_PREFIX_LIST=""
+IFS=',' read -r -a prefix_templates <<< "$MEMORIES_SOURCE_PREFIXES"
+for raw_prefix in "${prefix_templates[@]}"; do
+  raw_prefix=$(echo "$raw_prefix" | xargs)
+  [ -z "$raw_prefix" ] && continue
+
+  prefix=$(printf '%s' "$raw_prefix" | sed "s/{project}/$PROJECT/g")
+  query=$(query_for_prefix "$prefix")
+  limit=3
+  case "$prefix" in
+    claude-code/*|codex/*) limit=4 ;;
+    learning/*|wip/*) limit=2 ;;
+  esac
+
+  response=$(search_memories "$query" "$prefix" "$limit" "$MEMORIES_RECALL_SCOPED_THRESHOLD")
+  if [ -n "$response" ]; then
+    RAW_RESPONSES=$(printf '%s\n%s' "$RAW_RESPONSES" "$response")
+  fi
+
+  if [ -n "$SCOPED_PREFIX_LIST" ]; then
+    SCOPED_PREFIX_LIST="$SCOPED_PREFIX_LIST, "
+  fi
+  SCOPED_PREFIX_LIST="$SCOPED_PREFIX_LIST$prefix"
+done
+
+RESULTS_JSON=$(printf '%s\n' "$RAW_RESPONSES" | jq -sr --argjson limit "$RECALL_LIMIT" '
+  map(select(type == "object") | (.results // []))
+  | add
+  | unique_by(.id)
+  | sort_by(-(.similarity // .rrf_score // 0))
+  | .[0:$limit]
+' 2>/dev/null) || RESULTS_JSON="[]"
+
+if [ "$RESULTS_JSON" = "[]" ]; then
+  FALLBACK_RESPONSE=$(search_memories "project $PROJECT conventions decisions patterns" "" 6 "$MEMORIES_RECALL_FALLBACK_THRESHOLD")
+  RESULTS_JSON=$(printf '%s' "$FALLBACK_RESPONSE" | jq -c '.results // []' 2>/dev/null) || RESULTS_JSON="[]"
+fi
+
+CONTEXT_RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- [\(.source)] \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
+
+_log_info "Recalled $(printf '%s' "$RESULTS_JSON" | jq -r 'length' 2>/dev/null || echo 0) memories for $PROJECT"
+
+# Dedicated deferred-work surfacing
+WIP_QUERY="deferred incomplete blocked todo revisit wip"
+WIP_RESULTS=$(search_memories "$WIP_QUERY" "wip/$PROJECT" 5 0.3)
+WIP_COUNT=$(echo "$WIP_RESULTS" | jq -r '.count // 0')
+DEFERRED_SECTION=""
+if [ "$WIP_COUNT" -gt 0 ] && [ "$WIP_COUNT" != "null" ]; then
+  DEFERRED_ITEMS=$(echo "$WIP_RESULTS" | jq -r '.results[:5][] | "- [\(.source)] \(.text[0:150])"')
+  DEFERRED_SECTION="\n## Deferred Work\n$DEFERRED_ITEMS\n"
+fi
+
+PLAYBOOK=$(cat <<EOF
+## Memory Playbook
+
+- Treat hook-injected memories as a starting point, not the full search space.
+- Before answering questions about prior decisions, deferred work, architecture, or conventions, run project-scoped \`memory_search\` first.
+- Prefer these scoped prefixes before broader searches: $SCOPED_PREFIX_LIST.
+- For short follow-up prompts, include recent conversation context in the query instead of searching with the raw prompt alone.
+- If the retrieved memories show deferred or blocked work, answer that directly with words like \`not yet\`, \`deferred\`, or \`blocked on\` before expanding.
+- When a memory includes a boundary condition such as \`until\`, \`unless\`, or \`because\`, carry that clause forward in the answer instead of compressing it away.
+- Do not ask the user to reconfirm a remembered decision before you answer whether it still applies.
+EOF
+)
+
+# --- Hydrate auto-memory MEMORY.md ---
+# Claude Code's auto-memory loads MEMORY.md into every conversation (first 200 lines).
+# We sync top memories from MCP into a marked section so they're always in context,
+# while preserving any manually-pinned content above the marker.
+SYNC_MARKER="<!-- SYNCED-FROM-MEMORIES-MCP -->"
+ENCODED_CWD=$(echo "$CWD" | tr '/' '-')
+MEMORY_DIR="$HOME/.claude/projects/${ENCODED_CWD}/memory"
+MEMORY_FILE="$MEMORY_DIR/MEMORY.md"
+
+# Create memory dir if it doesn't exist (enables auto-memory for all projects)
+mkdir -p "$MEMORY_DIR" 2>/dev/null || true
+
+MEMORY_RESULTS=$(printf '%s' "$RESULTS_JSON" | jq -r '
+  if length == 0 then
+    empty
+  else
+    map("- \(.text)") | join("\n")
+  end
+' 2>/dev/null) || true
+
+if [ -n "$MEMORY_RESULTS" ] && [ "$MEMORY_RESULTS" != "null" ]; then
+  MANUAL_SECTION=""
+  if [ -f "$MEMORY_FILE" ]; then
+    # Preserve everything above the sync marker (manual/pinned content)
+    MARKER_LINE=$(grep -Fn "$SYNC_MARKER" "$MEMORY_FILE" 2>/dev/null | head -1 | cut -d: -f1) || true
+    if [ -n "$MARKER_LINE" ]; then
+      if [ "$MARKER_LINE" -gt 1 ]; then
+        MANUAL_SECTION=$(head -n $((MARKER_LINE - 1)) "$MEMORY_FILE")
+      else
+        MANUAL_SECTION=""
+      fi
+    else
+      MANUAL_SECTION=$(cat "$MEMORY_FILE")
+    fi
+  fi
+
+  # Write: manual section (preserved) + sync marker + fresh memories
+  {
+    if [ -n "$MANUAL_SECTION" ]; then
+      printf '%s\n' "$MANUAL_SECTION"
+      echo ""
+    fi
+    echo "$SYNC_MARKER"
+    echo "## Synced from Memories"
+    echo "$MEMORY_RESULTS"
+  } > "$MEMORY_FILE"
+fi
+
+# --- Output context for Claude Code ---
+jq -n --arg memories "$CONTEXT_RESULTS" --arg playbook "$PLAYBOOK" --arg health_warning "$HEALTH_WARNING" --arg deferred "$DEFERRED_SECTION" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: (
+      (if ($health_warning | length) > 0 then $health_warning + "\n\n" else "" end) +
+      (if ($memories | length) > 0 then "## Relevant Memories\n\n" + $memories + "\n\n" else "" end) +
+      (if ($deferred | length) > 0 then $deferred + "\n" else "" end) +
+      $playbook
+    )
+  }
+}'

--- a/mcp-server/hooks/memory-rehydrate.sh
+++ b/mcp-server/hooks/memory-rehydrate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# memory-rehydrate.sh — PostCompact hook
+# Fires after context compaction. Uses compact_summary as a targeted
+# search query to refresh the MEMORY.md sync section with the most
+# relevant memories for the post-compaction context.
+#
+# PostCompact does not support additionalContext injection, so this hook
+# updates the synced MEMORY.md section instead (same mechanism as
+# memory-recall.sh SessionStart hydration).
+
+set -euo pipefail
+
+MEMORIES_HOOK_NAME="memory-rehydrate"
+
+# Source env and shared lib
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_source_prefixes() { echo 'claude-code/{project},learning/{project},wip/{project}'; }
+fi
+
+INPUT=$(cat)
+
+# Extract compact summary
+SUMMARY=$(echo "$INPUT" | jq -r '.compact_summary // empty')
+[ -z "$SUMMARY" ] && { _log_warn "No compact_summary in input"; exit 0; }
+
+# Extract CWD and project for scoped search
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+PROJECT=$(basename "${CWD:-unknown}")
+[ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ] || [ -z "$PROJECT" ] && exit 0
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+
+# Truncate summary for use as query (max 500 chars)
+QUERY="${SUMMARY:0:500}"
+
+# Build source prefixes
+PREFIXES="${MEMORIES_SOURCE_PREFIXES:-$(_default_source_prefixes)}"
+
+# Search with the compact summary as query
+RESULTS=""
+for tpl in $(echo "$PREFIXES" | tr ',' ' '); do
+  prefix="${tpl//\{project\}/$PROJECT}"
+  BATCH=$(_search_memories_multi "$QUERY" "$prefix" 3 0.35) || { _log_error "Search failed for prefix $prefix"; continue; }
+
+  BATCH_RESULTS=$(echo "$BATCH" | jq -r '.results // []')
+  if [ -n "$RESULTS" ]; then
+    RESULTS=$(echo "$RESULTS $BATCH_RESULTS" | jq -s 'add | unique_by(.id) | sort_by(-.similarity // -.rrf_score) | .[0:6]')
+  else
+    RESULTS="$BATCH_RESULTS"
+  fi
+done
+
+# Hydrate MEMORY.md with post-compaction results (same sync-marker approach as recall)
+if [ -n "$RESULTS" ] && [ "$RESULTS" != "[]" ] && [ "$RESULTS" != "null" ]; then
+  FORMATTED=$(echo "$RESULTS" | jq -r '.[] | "- [\(.source // "unknown")] \(.text)"' 2>/dev/null)
+  if [ -n "$FORMATTED" ]; then
+    SYNC_MARKER="<!-- SYNCED-FROM-MEMORIES-MCP -->"
+    ENCODED_CWD=$(echo "$CWD" | sed 's|/|-|g; s|^-||')
+    MEMORY_DIR="$HOME/.claude/projects/${ENCODED_CWD}/memory"
+    MEMORY_FILE="$MEMORY_DIR/MEMORY.md"
+
+    if [ -d "$MEMORY_DIR" ] && [ -f "$MEMORY_FILE" ]; then
+      # Preserve manual content above sync marker, replace synced section
+      MANUAL_SECTION=$(sed "/$SYNC_MARKER/,\$d" "$MEMORY_FILE" 2>/dev/null || true)
+      {
+        [ -n "$MANUAL_SECTION" ] && printf '%s\n' "$MANUAL_SECTION"
+        echo "$SYNC_MARKER"
+        echo "## Synced from Memories (post-compaction)"
+        echo "$FORMATTED"
+      } > "$MEMORY_FILE"
+      _log_info "Rehydrated MEMORY.md with $(echo "$RESULTS" | jq 'length') memories after compaction"
+    else
+      _log_warn "MEMORY.md directory not found at $MEMORY_DIR"
+    fi
+  fi
+fi
+
+exit 0

--- a/mcp-server/hooks/memory-subagent-capture.sh
+++ b/mcp-server/hooks/memory-subagent-capture.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MEMORIES_HOOK_NAME="memory-subagent-capture"
+
+[ -f "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}" ] && . "${MEMORIES_ENV_FILE:-$HOME/.config/memories/env}"
+
+_LIB="$(dirname "$0")/_lib.sh"
+if [ -f "$_LIB" ]; then
+  source "$_LIB"
+else
+  _log_info() { :; }; _log_error() { :; }; _log_warn() { :; }
+  _rotate_log() { :; }; _health_check() { return 0; }
+  _default_extract_source() { echo 'claude-code/{project}'; }
+fi
+
+MEMORIES_URL="${MEMORIES_URL:-http://localhost:8900}"
+MEMORIES_API_KEY="${MEMORIES_API_KEY:-}"
+
+INPUT=$(cat)
+
+# Extract subagent details
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+# Prefer agent-specific transcript; fall back to main session transcript
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // .transcript_path // .transcriptPath // empty')
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
+
+# Only capture from Plan and Explore agents
+case "$AGENT_TYPE" in
+  Plan|Explore|plan|explore) ;;
+  *) exit 0 ;;
+esac
+
+PROJECT=$(basename "${CWD:-unknown}")
+[ "$PROJECT" = "/" ] || [ "$PROJECT" = "." ] || [ -z "$PROJECT" ] && exit 0
+
+# Build extraction source
+_DEFAULT_SRC="$(_default_extract_source)"
+SOURCE="${MEMORIES_EXTRACT_SOURCE:-$_DEFAULT_SRC}"
+SOURCE="${SOURCE//\{project\}/$PROJECT}"
+
+# Extract messages from transcript
+MESSAGES=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  MESSAGES=$(tail -200 "$TRANSCRIPT_PATH" 2>/dev/null | \
+    jq -r 'select(.type == "user" or .type == "assistant") |
+      if (.message.content | type) == "string" then
+        "\(.type): \(.message.content)"
+      elif (.message.content | type) == "array" then
+        "\(.type): \([.message.content[] | select(.type == "text") | .text] | join(" "))"
+      else empty end' 2>/dev/null | \
+    tail -6 | head -c 4000) || _log_warn "Failed to parse subagent transcript"
+fi
+
+[ -z "$MESSAGES" ] && { _log_info "No messages from $AGENT_TYPE subagent"; exit 0; }
+
+_log_info "Extracting from $AGENT_TYPE subagent ($PROJECT)"
+
+# Fire-and-forget extraction
+_extract_multi "$MESSAGES" "$SOURCE" "subagent_stop"
+
+exit 0

--- a/mcp-server/hooks/response-hints.json
+++ b/mcp-server/hooks/response-hints.json
@@ -1,0 +1,29 @@
+{
+  "patterns": [
+    {
+      "match": "still on|we're still|we are still|don't want to change|do not want to change",
+      "type": "context_continuation",
+      "template": "## Context Continuation Hint\nThe user is confirming a current choice or direction. If recalled memories show that choice, restate it with the stored trigger condition in the same sentence. Do not ask to reconfirm."
+    },
+    {
+      "match": "should we switch to|should we move to|should we change to",
+      "type": "switch_now",
+      "template": "## Follow-up Response Hint\nThe user is considering a switch. If a prior decision memory exists, state the current choice and why it was made. Then evaluate the proposed switch against the stored reasoning."
+    },
+    {
+      "match": "okay for now|fine for now|good enough for now|works for now",
+      "type": "simple_for_now",
+      "template": "## Follow-up Response Hint\nThe user accepts the current state provisionally. If a deferred-work or decision memory exists, preserve the boundary condition (e.g., 'until X') in the answer."
+    },
+    {
+      "match": "does that still apply|is that still true|still valid|still relevant",
+      "type": "confirmation",
+      "template": "## Follow-up Response Hint\nThe user is checking whether a prior decision or fact still holds. Search memories for the referenced topic. Answer directly: 'yes, still applies because...' or 'no, superseded by...'."
+    },
+    {
+      "match": "what about|how about|and for|regarding",
+      "type": "missing_piece",
+      "template": "## Follow-up Response Hint\nThe user is asking about a related aspect. Search memories for the new topic. If found, state it directly. If not found, say so clearly."
+    }
+  ]
+}

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -5,7 +5,19 @@
  *
  * Exposes the Memories service (localhost:8900) as MCP tools
  * for Claude Code, Claude Desktop, Codex, and any MCP client.
+ *
+ * Subcommands:
+ *   (none)           Start the MCP server (default)
+ *   install          Set up hooks and MCP config for Claude/Codex/Cursor/OpenClaw
+ *   uninstall        Remove hooks and MCP config
  */
+
+const subcommand = process.argv[2];
+if (subcommand === 'install' || subcommand === 'uninstall') {
+  const { run } = await import('./install.js');
+  await run(process.argv.slice(2));
+  process.exit(0);
+}
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/mcp-server/install.js
+++ b/mcp-server/install.js
@@ -1,0 +1,455 @@
+/**
+ * memories-mcp installer
+ *
+ * Sets up automatic memory hooks and MCP config for Claude Code, Codex,
+ * Cursor, and OpenClaw — without requiring the repo to be cloned.
+ *
+ * Usage:
+ *   npx memories-mcp install [--auto] [--claude] [--codex] [--cursor] [--openclaw] [--dry-run]
+ *   npx memories-mcp uninstall [--claude] [--codex] [--cursor] [--openclaw]
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const HOOKS_SRC = path.join(__dirname, 'hooks');
+const OPENCLAW_SKILL_SRC = path.join(__dirname, 'assets', 'openclaw-skill.md');
+const HOME = os.homedir();
+
+const RED    = '\x1b[31m';
+const GREEN  = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const BLUE   = '\x1b[34m';
+const NC     = '\x1b[0m';
+
+const ok   = (msg) => process.stdout.write(`  ${GREEN}[OK]${NC}   ${msg}\n`);
+const warn = (msg) => process.stdout.write(`  ${YELLOW}[WARN]${NC} ${msg}\n`);
+const fail = (msg) => process.stdout.write(`  ${RED}[FAIL]${NC} ${msg}\n`);
+const skip = (msg) => process.stdout.write(`  ${YELLOW}[SKIP]${NC} ${msg}\n`);
+const note = (msg) => process.stdout.write(`  ${YELLOW}[NOTE]${NC} ${msg}\n`);
+
+function ask(rl, question) {
+  return new Promise(resolve => rl.question(question, resolve));
+}
+
+function readJson(filePath) {
+  try { return JSON.parse(fs.readFileSync(filePath, 'utf8')); } catch { return {}; }
+}
+
+function writeJson(filePath, obj) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2) + '\n');
+}
+
+function mergeDeep(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+      result[key] = mergeDeep(target[key] || {}, source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+async function checkHealth(url) {
+  try {
+    const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(5000) });
+    if (res.ok) return await res.json();
+  } catch {}
+  return null;
+}
+
+function renderHooksJson(hooksDir, codexOnly = false) {
+  const raw = JSON.parse(fs.readFileSync(path.join(HOOKS_SRC, 'hooks.json'), 'utf8'));
+  const codexEvents = new Set(['SessionStart', 'UserPromptSubmit', 'Stop', 'PreCompact', 'SessionEnd']);
+  const filtered = {};
+  for (const [event, matchers] of Object.entries(raw.hooks)) {
+    if (codexOnly && !codexEvents.has(event)) continue;
+    filtered[event] = matchers.map(matcher => ({
+      ...matcher,
+      hooks: matcher.hooks.map(hook => {
+        if (hook.type !== 'command') return hook;
+        // Replace the env-var-based path with the resolved install path
+        const scriptName = path.basename(hook.command.replace(/^\$\{[^}]+\}\//, ''));
+        return { ...hook, command: path.join(hooksDir, scriptName) };
+      }),
+    }));
+  }
+  return { hooks: filtered };
+}
+
+function installHooks(label, hooksDir, settingsFile, codexOnly = false) {
+  fs.mkdirSync(hooksDir, { recursive: true });
+
+  for (const file of fs.readdirSync(HOOKS_SRC)) {
+    if (file === 'hooks.json') continue;
+    const dst = path.join(hooksDir, file);
+    fs.copyFileSync(path.join(HOOKS_SRC, file), dst);
+    if (file.endsWith('.sh')) fs.chmodSync(dst, 0o755);
+  }
+  ok(`Installed ${label} hooks: ${hooksDir}`);
+
+  fs.mkdirSync(path.dirname(settingsFile), { recursive: true });
+  if (!fs.existsSync(settingsFile)) writeJson(settingsFile, {});
+
+  const existing = readJson(settingsFile);
+  const hooksPatch = renderHooksJson(hooksDir, codexOnly);
+  writeJson(settingsFile, mergeDeep(existing, { hooks: hooksPatch.hooks }));
+  ok(`Merged hook config into ${settingsFile}`);
+
+  const readonlyTools = [
+    'mcp__memories__memory_search',
+    'mcp__memories__memory_list',
+    'mcp__memories__memory_count',
+    'mcp__memories__memory_stats',
+    'mcp__memories__memory_is_novel',
+    'mcp__memories__memory_is_useful',
+    'mcp__memories__memory_conflicts',
+  ];
+  const withPerms = readJson(settingsFile);
+  const existingAllow = withPerms.permissions?.allow || [];
+  withPerms.permissions = {
+    ...(withPerms.permissions || {}),
+    allow: [...new Set([...existingAllow, ...readonlyTools])],
+  };
+  writeJson(settingsFile, withPerms);
+  ok(`Merged read-only tool permissions into ${settingsFile}`);
+}
+
+function installMcpJson(label, settingsFile, memoriesUrl, memoriesApiKey) {
+  fs.mkdirSync(path.dirname(settingsFile), { recursive: true });
+  if (!fs.existsSync(settingsFile)) writeJson(settingsFile, {});
+
+  const existing = readJson(settingsFile);
+  if (existing.mcpServers?.memories) {
+    skip(`${label} MCP 'memories' already configured in ${settingsFile}`);
+    return;
+  }
+
+  writeJson(settingsFile, mergeDeep(existing, {
+    mcpServers: {
+      memories: {
+        command: 'npx',
+        args: ['-y', 'memories-mcp'],
+        env: { MEMORIES_URL: memoriesUrl, MEMORIES_API_KEY: memoriesApiKey },
+      },
+    },
+  }));
+  ok(`Added ${label} MCP config in ${settingsFile}`);
+}
+
+function appendTomlBlock(filePath, marker, body) {
+  let content = '';
+  try { content = fs.readFileSync(filePath, 'utf8'); } catch {}
+  if (content.includes(`# BEGIN ${marker}`)) return false;
+  fs.appendFileSync(filePath, `\n# BEGIN ${marker}\n${body}\n# END ${marker}\n`);
+  return true;
+}
+
+function removeTomlBlock(filePath, marker) {
+  let content = '';
+  try { content = fs.readFileSync(filePath, 'utf8'); } catch { return; }
+  const start = `# BEGIN ${marker}`;
+  const end = `# END ${marker}`;
+  if (!content.includes(start)) return;
+  const lines = content.split('\n');
+  const out = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (line === start) { inBlock = true; continue; }
+    if (line === end)   { inBlock = false; continue; }
+    if (!inBlock) out.push(line);
+  }
+  fs.writeFileSync(filePath, out.join('\n'));
+  ok(`Removed ${marker} from ${filePath}`);
+}
+
+function writeEnvVar(envFile, name, value) {
+  let content = '';
+  try { content = fs.readFileSync(envFile, 'utf8'); } catch {}
+  if (content.split('\n').some(l => l.startsWith(`${name}=`))) {
+    skip(`${name} already in ${envFile}`);
+    return;
+  }
+  fs.appendFileSync(envFile, `${name}="${value}"\n`);
+  ok(`${name} → ${envFile}`);
+}
+
+function printHelp() {
+  process.stdout.write(`
+memories-mcp — set up automatic memory hooks and MCP config
+
+Usage:
+  npx memories-mcp install   [--auto] [--claude] [--codex] [--cursor] [--openclaw] [--dry-run]
+  npx memories-mcp uninstall [--auto] [--claude] [--codex] [--cursor] [--openclaw]
+
+Options:
+  --auto       Auto-detect installed tools (default)
+  --claude     Install Claude Code hooks + MCP
+  --codex      Install Codex hooks + MCP + developer instructions
+  --cursor     Install Cursor hooks + MCP
+  --openclaw   Install OpenClaw skill
+  --dry-run    Print detected targets and exit without writing
+  -h, --help   Show this help
+
+Environment:
+  MEMORIES_URL      Service URL (default: http://localhost:8900)
+  MEMORIES_API_KEY  API key if auth is enabled
+
+Examples:
+  npx memories-mcp install
+  npx memories-mcp install --claude --codex --cursor
+  npx memories-mcp uninstall --cursor
+`);
+}
+
+export async function run(argv) {
+  let targetClaude    = false;
+  let targetCodex     = false;
+  let targetCursor    = false;
+  let targetOpenclaw  = false;
+  let explicitTargets = false;
+  let autoDetect      = true;
+  let uninstall       = false;
+  let dryRun          = false;
+
+  for (const arg of argv) {
+    switch (arg) {
+      case 'install':   break;
+      case 'uninstall': uninstall = true; break;
+      case '--auto':    autoDetect = true; break;
+      case '--claude':  targetClaude   = true; explicitTargets = true; autoDetect = false; break;
+      case '--codex':   targetCodex    = true; explicitTargets = true; autoDetect = false; break;
+      case '--cursor':  targetCursor   = true; explicitTargets = true; autoDetect = false; break;
+      case '--openclaw':targetOpenclaw = true; explicitTargets = true; autoDetect = false; break;
+      case '--uninstall': uninstall = true; break;
+      case '--dry-run': dryRun = true; break;
+      case '-h': case '--help': printHelp(); return;
+      default:
+        process.stderr.write(`Unknown argument: ${arg}\n`);
+        printHelp();
+        process.exit(1);
+    }
+  }
+
+  if (autoDetect && !explicitTargets) {
+    if (fs.existsSync(path.join(HOME, '.claude')))   targetClaude   = true;
+    if (fs.existsSync(path.join(HOME, '.codex')))    targetCodex    = true;
+    if (fs.existsSync(path.join(HOME, '.cursor')))   targetCursor   = true;
+    if (fs.existsSync(path.join(HOME, '.openclaw'))) targetOpenclaw = true;
+  }
+
+  // First-time fallback: at least install Claude
+  if (!targetClaude && !targetCodex && !targetCursor && !targetOpenclaw) {
+    targetClaude = true;
+  }
+
+  const targets = [
+    targetClaude   && 'claude',
+    targetCodex    && 'codex',
+    targetCursor   && 'cursor',
+    targetOpenclaw && 'openclaw',
+  ].filter(Boolean);
+
+  if (dryRun) {
+    process.stdout.write(`targets=${targets.join(',')}\n`);
+    process.stdout.write(`mode=${uninstall ? 'uninstall' : 'install'}\n`);
+    return;
+  }
+
+  process.stdout.write(`\n${BLUE}Memories — Automatic Memory Layer Setup${NC}\n`);
+  process.stdout.write(`${BLUE}============================================${NC}\n`);
+  process.stdout.write(`Targets: ${GREEN}${targets.join(', ')}${NC}\n\n`);
+
+  // ── Uninstall ──────────────────────────────────────────────────────────────
+  if (uninstall) {
+    if (targetClaude) {
+      try { fs.rmSync(path.join(HOME, '.claude', 'hooks', 'memory'), { recursive: true }); ok('Removed Claude hooks'); }
+      catch { warn('Claude hooks dir not found, skipping'); }
+      const f = path.join(HOME, '.claude', 'settings.json');
+      if (fs.existsSync(f)) {
+        const s = readJson(f);
+        if (s.mcpServers?.memories) {
+          delete s.mcpServers.memories;
+          if (!Object.keys(s.mcpServers).length) delete s.mcpServers;
+          writeJson(f, s);
+          ok(`Removed memories MCP from ${f}`);
+        }
+      }
+    }
+    if (targetCodex) {
+      try { fs.rmSync(path.join(HOME, '.codex', 'hooks', 'memory'), { recursive: true }); ok('Removed Codex hooks'); }
+      catch { warn('Codex hooks dir not found, skipping'); }
+      const cfg = path.join(HOME, '.codex', 'config.toml');
+      removeTomlBlock(cfg, 'Memories Codex MCP');
+      removeTomlBlock(cfg, 'Memories Codex developer instructions');
+    }
+    if (targetCursor) {
+      const f = path.join(HOME, '.cursor', 'mcp.json');
+      if (fs.existsSync(f)) {
+        const s = readJson(f);
+        if (s.mcpServers?.memories) {
+          delete s.mcpServers.memories;
+          if (!Object.keys(s.mcpServers).length) delete s.mcpServers;
+          writeJson(f, s);
+          ok(`Removed memories MCP from ${f}`);
+        }
+      }
+    }
+    if (targetOpenclaw) {
+      try { fs.rmSync(path.join(HOME, '.openclaw', 'skills', 'memories'), { recursive: true }); ok('Removed OpenClaw skill'); }
+      catch { warn('OpenClaw skill dir not found, skipping'); }
+    }
+    process.stdout.write(`\n${GREEN}Uninstall complete.${NC}\n`);
+    return;
+  }
+
+  // ── Health check ───────────────────────────────────────────────────────────
+  const memoriesUrl    = process.env.MEMORIES_URL     || 'http://localhost:8900';
+  const memoriesApiKey = process.env.MEMORIES_API_KEY || '';
+
+  process.stdout.write(`[1/4] Checking Memories service at ${BLUE}${memoriesUrl}${NC}...\n`);
+  const health = await checkHealth(memoriesUrl);
+  if (!health) {
+    fail(`Memories service not reachable at ${memoriesUrl}`);
+    process.stdout.write('       Start it with: docker compose up -d\n');
+    process.exit(1);
+  }
+  ok(`Healthy (${health.total_memories ?? 0} memories)\n`);
+
+  // ── Extraction provider ────────────────────────────────────────────────────
+  const hasHookTargets = targetClaude || targetCodex || targetCursor;
+  let extractProvider = '';
+  let extractEnvVars  = {};
+
+  if (hasHookTargets && process.stdin.isTTY) {
+    process.stdout.write('[2/4] Extraction provider (for automatic learning):\n');
+    process.stdout.write('  1. Anthropic (recommended, ~$0.001/turn, full AUDN)\n');
+    process.stdout.write('  2. OpenAI (~$0.001/turn, full AUDN)\n');
+    process.stdout.write('  3. Ollama (free, local)\n');
+    process.stdout.write('  4. Skip (retrieval only)\n\n');
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const choice = (await ask(rl, '  > ')).trim();
+
+    if (choice === '1') {
+      extractProvider = 'anthropic';
+      const key = (await ask(rl, '  Anthropic API key: ')).trim();
+      if (!key) { fail('API key required'); rl.close(); process.exit(1); }
+      extractEnvVars['ANTHROPIC_API_KEY'] = key;
+    } else if (choice === '2') {
+      extractProvider = 'openai';
+      const key = (await ask(rl, '  OpenAI API key: ')).trim();
+      if (!key) { fail('API key required'); rl.close(); process.exit(1); }
+      extractEnvVars['OPENAI_API_KEY'] = key;
+    } else if (choice === '3') {
+      extractProvider = 'ollama';
+    } else {
+      warn('Extraction disabled (retrieval-only mode)');
+    }
+    rl.close();
+  } else if (hasHookTargets) {
+    process.stdout.write('[2/4] Non-interactive: skipping extraction provider prompt.\n');
+  }
+  process.stdout.write('\n');
+
+  // ── Install targets ────────────────────────────────────────────────────────
+  process.stdout.write('[3/4] Installing...\n');
+
+  if (targetClaude) {
+    installHooks('Claude', path.join(HOME, '.claude', 'hooks', 'memory'), path.join(HOME, '.claude', 'settings.json'));
+    installMcpJson('Claude', path.join(HOME, '.claude', 'settings.json'), memoriesUrl, memoriesApiKey);
+  }
+
+  if (targetCodex) {
+    const codexHooksDir = path.join(HOME, '.codex', 'hooks', 'memory');
+    const codexSettings = path.join(HOME, '.codex', 'settings.json');
+    const codexConfig   = path.join(HOME, '.codex', 'config.toml');
+
+    installHooks('Codex', codexHooksDir, codexSettings, true);
+
+    fs.mkdirSync(path.dirname(codexConfig), { recursive: true });
+    if (!fs.existsSync(codexConfig)) fs.writeFileSync(codexConfig, '');
+
+    const mcpBlock =
+`[mcp_servers.memories]
+command = "npx"
+args = ["-y", "memories-mcp"]
+
+[mcp_servers.memories.env]
+MEMORIES_URL = "${memoriesUrl}"
+MEMORIES_API_KEY = "${memoriesApiKey}"`;
+
+    if (appendTomlBlock(codexConfig, 'Memories Codex MCP', mcpBlock)) {
+      ok(`Added Codex MCP config in ${codexConfig}`);
+    } else {
+      skip('Codex MCP already configured');
+    }
+
+    const devInstr =
+`developer_instructions = """
+Use the Memories MCP tools as your memory layer with three responsibilities:
+
+1. READ: Run memory_search before implementation-heavy responses or clarifying questions.
+2. WRITE: Use memory_add for single clear facts (check memory_is_novel first). Use memory_extract for rich conversations, decision changes, or deferred work updates — it handles Add/Update/Delete/Noop automatically via AUDN.
+3. MAINTAIN: Use memory_delete for explicit forget requests. memory_extract handles most lifecycle updates automatically.
+
+Source prefixes: codex/{project} for decisions, learning/{project} for fixes, wip/{project} for deferred work.
+"""`;
+
+    if (appendTomlBlock(codexConfig, 'Memories Codex developer instructions', devInstr)) {
+      ok(`Added Codex developer instructions in ${codexConfig}`);
+    } else {
+      skip('Codex developer instructions already configured');
+    }
+  }
+
+  if (targetCursor) {
+    // Cursor reads Claude Code's ~/.claude/settings.json via Third-party skills
+    installHooks('Cursor', path.join(HOME, '.claude', 'hooks', 'memory'), path.join(HOME, '.claude', 'settings.json'));
+    installMcpJson('Cursor', path.join(HOME, '.cursor', 'mcp.json'), memoriesUrl, memoriesApiKey);
+    process.stdout.write(`\n  ${YELLOW}[ACTION REQUIRED]${NC} Enable third-party hooks in Cursor:\n`);
+    process.stdout.write('  Settings → Features → Third-party skills → toggle ON\n');
+    process.stdout.write('  Then restart Cursor.\n');
+  }
+
+  if (targetOpenclaw) {
+    const skillDir = path.join(HOME, '.openclaw', 'skills', 'memories');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.copyFileSync(OPENCLAW_SKILL_SRC, path.join(skillDir, 'SKILL.md'));
+    ok(`Installed OpenClaw skill: ${skillDir}/SKILL.md`);
+  }
+
+  // ── Write env files ────────────────────────────────────────────────────────
+  process.stdout.write('\n[4/4] Writing configuration...\n');
+
+  const envDir  = path.join(HOME, '.config', 'memories');
+  const envFile = path.join(envDir, 'env');
+  fs.mkdirSync(envDir, { recursive: true });
+  if (!fs.existsSync(envFile)) fs.writeFileSync(envFile, '');
+
+  writeEnvVar(envFile, 'MEMORIES_URL', memoriesUrl);
+  if (memoriesApiKey) writeEnvVar(envFile, 'MEMORIES_API_KEY', memoriesApiKey);
+  if (extractProvider) writeEnvVar(envFile, 'EXTRACT_PROVIDER', extractProvider);
+  for (const [k, v] of Object.entries(extractEnvVars)) writeEnvVar(envFile, k, v);
+
+  // ── Summary ────────────────────────────────────────────────────────────────
+  process.stdout.write(`\n${GREEN}Done.${NC}\n`);
+  process.stdout.write(`Installed: ${BLUE}${targets.join(', ')}${NC}\n`);
+  process.stdout.write(`Hook env:  ${BLUE}${envFile}${NC}\n`);
+
+  if (extractProvider) {
+    process.stdout.write(`\n`);
+    note(`Set EXTRACT_PROVIDER=${extractProvider} in your docker-compose environment`);
+    note(`(or .env file next to docker-compose.yml) to enable extraction in the service.`);
+    for (const k of Object.keys(extractEnvVars)) {
+      note(`Also set ${k} in the same file.`);
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -4,8 +4,18 @@
   "description": "MCP server for Memories — semantic search, add, extract, delete, browse",
   "type": "module",
   "main": "index.js",
+  "bin": {
+    "memories-mcp": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "install.js",
+    "hooks/",
+    "assets/"
+  ],
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "prepack": "cp -r ../integrations/claude-code/hooks/. ./hooks/ && cp ../integrations/openclaw-skill.md ./assets/openclaw-skill.md"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",


### PR DESCRIPTION
## Summary

This PR makes memories significantly easier to install by eliminating the need to clone the repository for everyday use. There are three self-contained changes:

### 1. Pre-built Docker image on GHCR (`.github/workflows/docker-publish.yml`)

Adds a GitHub Actions workflow that builds and pushes the service image to `ghcr.io/divyekant/memories` on every push to `main` and on version tags.

- Builds both `core` and `extract` targets in parallel
- Multi-arch: `linux/amd64` + `linux/arm64` (native Apple Silicon pulls)
- Uses GHA layer cache per target for fast repeat builds
- No secrets to configure — uses the built-in `GITHUB_TOKEN`
- Tag strategy on `v5.0.1`: `5.0.1`, `5.0`, `latest` (core) and `5.0.1-extract`, `5.0-extract`, `extract`
- Pushes to `main` produce `edge` / `edge-extract` channel tags

### 2. Standalone compose file (`docker-compose.standalone.yml`)

A ready-to-use compose file that pulls the pre-built image instead of building from source. Identical environment config to the main `docker-compose.yml`. Uses named Docker volumes so there is no dependency on a local `./data` path.

Users can now start the full service without cloning:

```bash
curl -fsSL https://raw.githubusercontent.com/divyekant/memories/main/docker-compose.standalone.yml -o docker-compose.yml
docker compose up -d
```

To use the extraction-capable image: `MEMORIES_IMAGE_TAG=extract docker compose up -d`

### 3. `memories-mcp` npm package (`mcp-server/`)

The MCP server is now publishable to npm, removing the last reason to clone for MCP client setup.

**`mcp-server/package.json`** gains:
- `"bin": { "memories-mcp": "./index.js" }` — makes it runnable via `npx`
- `"files"` — scopes publish to `index.js`, `install.js`, `hooks/`, `assets/`
- `"prepack"` — syncs hook scripts and the OpenClaw skill from their canonical locations before each publish, so the package is always up-to-date

**`mcp-server/install.js`** is a new Node.js installer (port of `integrations/claude-code/install.sh`) that:
- Auto-detects Claude Code, Codex, Cursor, and OpenClaw
- Prompts for extraction provider (Anthropic / OpenAI / Ollama / skip)
- Copies hook scripts to the correct target directories
- Writes MCP config using `npx -y memories-mcp` — **no hardcoded paths**
- Writes `~/.config/memories/env`
- Has no external dependencies (`jq` and `curl` not required — uses built-in `fetch` and JSON)
- Supports `--claude`, `--codex`, `--cursor`, `--openclaw`, `--dry-run`, `--uninstall`

**`mcp-server/index.js`** dispatches `install`/`uninstall` subcommands before starting the MCP server.

**`.github/workflows/npm-publish.yml`** publishes to npm on `v*` tags with `--provenance`. Requires one repo secret: `NPM_TOKEN`.

### Before / after: Cursor + extraction

**Before this PR:**
1. `git clone git@github.com:divyekant/memories.git && cd memories`
2. `MEMORIES_IMAGE_TARGET=extract docker compose up -d --build` (5–10 min build)
3. `cd mcp-server && npm install`
4. Manually edit `~/.cursor/mcp.json` with absolute path to `mcp-server/index.js`
5. `./integrations/claude-code/install.sh --cursor` (also requires clone)

**After this PR:**
1. `curl -fsSL .../docker-compose.standalone.yml -o docker-compose.yml && MEMORIES_IMAGE_TAG=extract docker compose up -d`
2. Add to `~/.cursor/mcp.json`: `{ "command": "npx", "args": ["-y", "memories-mcp"] }`
3. `npx memories-mcp install --cursor`

No clone. No build. No local path to manage.

---

## Notes for merge

- The npm publish workflow requires an `NPM_TOKEN` secret added to this repo's Actions secrets (Settings → Secrets → Actions). The token needs `publish` scope on the `memories-mcp` package on npmjs.com.
- The Docker workflow uses only the built-in `GITHUB_TOKEN` — no secrets needed.
- The existing `integrations/claude-code/install.sh` is **unchanged** — it continues to work for users who have cloned the repo.
- `mcp-server/hooks/` contains copies of the canonical hook scripts from `integrations/claude-code/hooks/`. The `prepack` script keeps them in sync at publish time.

## Test plan

- [ ] Merge and push a `v*` tag; verify both `docker-publish` and `npm-publish` workflows succeed
- [ ] `docker pull ghcr.io/divyekant/memories:latest` and verify the image starts cleanly
- [ ] `npx memories-mcp --help` returns usage
- [ ] `npx memories-mcp install --dry-run` prints detected targets without writing files
- [ ] `npx memories-mcp install --cursor` with service running: verify `~/.cursor/mcp.json` contains `npx` entry and hooks land in `~/.claude/hooks/memory/`
- [ ] Verify existing `install.sh --cursor` still works for clone-based users

Made with [Cursor](https://cursor.com)