### PR TITLE
Add OpenCode integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **First-class OpenCode integration** — installer target, OpenCode MCP config merge, marker-safe Memories skill install, repo-local OpenCode plugin registration, prompt-time recall context, and active-search telemetry with `client=opencode`.
+
 ## [5.4.0] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-- **First-class OpenCode integration** — installer target, OpenCode MCP config merge, marker-safe Memories skill install, repo-local OpenCode plugin registration, prompt-time recall context, and active-search telemetry with `client=opencode`.
-
 ## [5.4.0] - 2026-05-04
 
 ### Added
+- **First-class OpenCode integration** — installer target, OpenCode MCP config merge, marker-safe Memories skill install, repo-local OpenCode plugin registration, prompt-time recall context, and active-search telemetry with `client=opencode`.
 - **Enterprise eval isolation** — eval runners now validate setup before execution, require eval-scoped API keys, reject unsafe production targets by default, and record ready-before/after evidence so eval runs can prove they did not contaminate production data.
 - **Active-search behavior evals** — added realistic Codex and Claude Code eval coverage that checks required `memory_search` use, exact project source prefixes, passive-hook-only failures, unnecessary control-case searches, and whether retrieved memory affected the answer.
 - **Active-search monitoring** — hooks now emit privacy-safe local JSONL telemetry for required prompts and memory tool calls, with `scripts/active_search_metrics.py` summarizing follow-up rate, passive-risk prompts, exact project searches, and broad/unscoped searches.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local semantic memory for AI assistants. Zero-cost, <50ms, hybrid BM25+vector search.
 
-Works with **Claude Code**, **Claude Desktop**, **Claude Chat**, **Codex**, **Cursor**, **ChatGPT**, **OpenClaw**, and anything that can call HTTP or MCP.
+Works with **Claude Code**, **Claude Desktop**, **Claude Chat**, **Codex**, **OpenCode**, **Cursor**, **ChatGPT**, **OpenClaw**, and anything that can call HTTP or MCP.
 
 **Key capabilities (v5.4.0):**
 - **Hybrid search** — BM25 + vector + recency + feedback + confidence + graph (6-signal RRF fusion with PPR-scored graph expansion)
@@ -162,9 +162,10 @@ Config resolution: CLI flags > `~/.config/memories/config.json` > env vars > def
 ## Architecture
 
 ```
-AI Client (Claude, Codex, Cursor, ChatGPT, OpenClaw)
+AI Client (Claude, Codex, OpenCode, Cursor, ChatGPT, OpenClaw)
     |
-    |-- MCP protocol (Claude Code / Desktop / Codex / Cursor)
+    |-- MCP protocol (Claude Code / Desktop / Codex / OpenCode / Cursor)
+    |-- Client hooks/plugins (Claude Code / Codex / OpenCode / Cursor)
     |-- REST API (everything else)
     v
 MCP Server (mcp-server/index.js)
@@ -377,6 +378,32 @@ Codex uses `~/.codex/hooks.json` for lifecycle hooks, `~/.codex/settings.json` f
 - "Search memory for how we handle error logging"
 - "Store this architecture decision in memory"
 - "List all memories from the project-setup source"
+
+---
+
+### OpenCode
+
+OpenCode uses Memories through MCP plus OpenCode plugin hooks. It does not use Claude Code or Codex shell hooks.
+
+**Setup:**
+
+```bash
+cd memories
+npm --prefix ./mcp-server install
+./integrations/claude-code/install.sh --opencode
+```
+
+This configures:
+- `~/.config/opencode/opencode.json` with a merged `mcp.memories` local server entry
+- a `zsh -lc` MCP command that sources `~/.config/memories/env` and runs `mcp-server/index.js`
+- the repo-local plugin path `integrations/opencode/plugin/memories.js`
+- the Memories skill at `~/.config/opencode/skills/memories/SKILL.md` with marker-safe behavior
+
+The plugin reads `~/.config/memories/env` by default for `MEMORIES_URL`, `MEMORIES_API_KEY`, `MEMORIES_ACTIVE_SEARCH_LOG`, and `MEMORIES_ACTIVE_SEARCH_METRICS`. It injects prompt-time recall context and records active-search `tool_call` telemetry for memory tool calls with `client=opencode` to `~/.config/memories/active-search.jsonl` unless metrics are disabled. It searches exact project prefixes first in this order: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, `wip/{project}`.
+
+OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added. The first implementation does not auto-extract by default because automatic extraction remains gated until reliable OpenCode end-of-turn transcript access is proven.
+
+See [`integrations/opencode/README.md`](integrations/opencode/README.md) for details.
 
 ---
 
@@ -676,7 +703,7 @@ ingress:
 }
 ```
 
-Now every client — Claude Code on your laptop, Cursor, Claude Desktop on your phone, ChatGPT, OpenClaw — all hit the same memory store running on your Mac mini.
+Now every client — Claude Code on your laptop, Codex, OpenCode, Cursor, Claude Desktop on your phone, ChatGPT, OpenClaw — all hit the same memory store running on your Mac mini.
 
 ---
 
@@ -714,7 +741,7 @@ backends:
 
 Config supports env var interpolation (`${VAR_NAME}`) for API keys and URLs.
 
-Multi-backend works automatically with **Claude Code**, **Codex**, and **Cursor** because they all use the same hook scripts. **OpenClaw** does not yet support multi-backend (it uses skill-based extraction, not hooks).
+Multi-backend works automatically with **Claude Code**, **Codex**, and **Cursor** because their hook paths read `backends.yaml`. **OpenCode** currently uses MCP plus plugin prompt recall and memory-tool telemetry, not shell-hook routing. **OpenClaw** does not yet support multi-backend (it uses skill-based extraction, not hooks).
 
 For full setup instructions, config format, and verification steps, see the [Multi-Backend Setup](integrations/QUICKSTART-LLM.md#multi-backend-setup-optional) section in the LLM quickstart guide.
 
@@ -990,6 +1017,7 @@ Memories supports automatic retrieval/extraction, with client-specific behavior:
 - Claude Code: full 12-hook lifecycle (session start, each prompt, after response, pre-compact, post-compact, subagent start, subagent stop, tool use, tool observe, file write guard, config change, session end)
 - Cursor: same 12-hook lifecycle via Third-party skills (loads from `~/.claude/settings.json`)
 - Codex: 5-hook lifecycle via `~/.codex/hooks.json` + permissions in `~/.codex/settings.json` + MCP/developer instructions in `~/.codex/config.toml`
+- OpenCode: MCP plus OpenCode plugin hooks for prompt-time recall context and active-search telemetry; auto-extraction is gated until reliable end-of-turn transcript access is proven
 - OpenClaw: skill-driven retrieval/extraction flow
 
 ### Claude Code / Cursor Hook Lifecycle
@@ -1024,16 +1052,25 @@ Memories supports automatic retrieval/extraction, with client-specific behavior:
 
 Codex uses `~/.codex/hooks.json` for these hooks, `~/.codex/settings.json` for permissions, and `~/.codex/config.toml` for MCP + developer instructions. Its `Stop` hook is intentionally beefier because Codex does not expose `PreCompact` or `SessionEnd`.
 
+### OpenCode Lifecycle
+
+| Event | Mechanism | What happens |
+|-------|-----------|--------------|
+| Prompt context | OpenCode plugin `experimental.chat.system.transform` | Injects recall guidance and recent project memories |
+| Memory MCP tool calls | OpenCode plugin `tool.execute.after` | Logs active-search telemetry with `client=opencode` |
+| MCP tools | `~/.config/opencode/opencode.json` `mcp.memories` | Exposes Memories MCP tools through a local `zsh -lc` command that sources `~/.config/memories/env` |
+
+OpenCode searches exact project prefixes first: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, `wip/{project}`. OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added; the first implementation does not auto-extract by default.
+
 ### Quick setup
 
 **Prerequisites:**
 - `jq` and `curl` installed (required by installer)
 - running Memories service (`curl -s http://localhost:8900/health | jq .`)
-- if installing Codex integration, MCP deps installed:
+- if installing Codex or OpenCode integration, MCP deps installed:
 
 ```bash
-cd memories/mcp-server
-npm install
+npm --prefix ./mcp-server install
 ```
 
 **One-command auto-detect installer (recommended):**
@@ -1044,6 +1081,7 @@ npm install
 This detects and configures any available targets on your machine:
 - Claude Code hooks (`~/.claude/settings.json`)
 - Codex hooks (`~/.codex/hooks.json`) + permissions (`~/.codex/settings.json`) + MCP/developer instructions (`~/.codex/config.toml`)
+- OpenCode MCP/plugin config (`~/.config/opencode/opencode.json`) + Memories skill (`~/.config/opencode/skills/memories/SKILL.md`)
 - OpenClaw skill (`~/.openclaw/skills/memories/SKILL.md`)
 
 Cursor is supported via manual MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json`).
@@ -1056,12 +1094,14 @@ The installer writes runtime config to:
 Claude/Cursor read hooks also support an optional `MEMORIES_SOURCE_PREFIXES` env var in
 `~/.config/memories/env`. It is a comma-separated list of source prefix templates and
 defaults to `claude-code/{project},codex/{project},learning/{project},wip/{project}` for Claude Code and `codex/{project},claude-code/{project},learning/{project},wip/{project}` for Codex.
+OpenCode plugin recall defaults to `opencode/{project},claude-code/{project},codex/{project},learning/{project},wip/{project}`.
 
-**Target only Claude, Cursor, or Codex:**
+**Target only Claude, Cursor, Codex, or OpenCode:**
 ```bash
 ./integrations/claude-code/install.sh --claude
 ./integrations/claude-code/install.sh --cursor
 ./integrations/claude-code/install.sh --codex
+./integrations/claude-code/install.sh --opencode
 ```
 
 **Target only OpenClaw:**
@@ -1362,7 +1402,7 @@ memories/
     app.js                # Browser-side pagination/filter logic
   integrations/
     claude-code/
-      install.sh          # Auto-detect installer (Claude/Codex/Cursor/OpenClaw)
+      install.sh          # Auto-detect installer (Claude/Codex/OpenCode/Cursor/OpenClaw)
       hooks/              # Claude Code 12-hook scripts + hooks.json
         _lib.sh               # Shared hook utilities (logging, health check)
         memory-rehydrate.sh   # PostCompact rehydration hook
@@ -1373,6 +1413,10 @@ memories/
         response-hints.json   # Response hint patterns
     codex/
       memory-codex-notify.sh # Legacy Codex notify hook (compatibility/manual fallback)
+    opencode/
+      README.md           # OpenCode setup and lifecycle notes
+      plugin/
+        memories.js       # OpenCode prompt recall + telemetry plugin
     claude-code.md        # Claude Code guide
     openclaw-skill.md     # OpenClaw SKILL.md
     QUICKSTART-LLM.md     # LLM-friendly setup guide

--- a/docs/active-search-monitoring.md
+++ b/docs/active-search-monitoring.md
@@ -5,7 +5,7 @@ actually using Memories the way the active-search eval expects.
 
 ## What Gets Logged
 
-Claude Code and Codex hooks append local JSONL telemetry to:
+Claude Code and Codex hooks, plus the OpenCode plugin, append local JSONL telemetry to:
 
 ```bash
 ~/.config/memories/active-search.jsonl
@@ -23,10 +23,10 @@ Disable local telemetry with:
 MEMORIES_ACTIVE_SEARCH_METRICS=0
 ```
 
-The log is metadata-only. It stores:
+The log is metadata-only. Claude Code and Codex hooks can store prompt and tool metadata:
 
 - timestamp
-- client (`claude-code` or `codex`)
+- client (`claude-code`, `codex`, or `opencode`)
 - session id
 - project basename
 - SHA-256 prompt hash
@@ -35,6 +35,8 @@ The log is metadata-only. It stores:
 - memory tool name
 - memory tool source prefix
 - source-prefix quality (`exact_project`, `broad_or_unscoped`, or `other`)
+
+OpenCode currently logs memory tool-call telemetry only (`event: "tool_call"`) through its plugin. It does not emit `prompt_evaluated` events yet, so prompt classification, candidate-count, follow-up-rate, and passive-risk metrics are Claude/Codex hook metrics only for now.
 
 It does not store prompt text, memory text, retrieved snippets, or API keys.
 
@@ -50,17 +52,15 @@ Run:
 
 Key fields:
 
-- `active_search_followup_rate`: fraction of required prompts followed by
-  `memory_search` within the window.
-- `passive_risk_prompts`: required prompts with no observed follow-up
-  `memory_search`.
+- `active_search_followup_rate`: fraction of required Claude/Codex hook prompts followed by `memory_search` within the window. OpenCode is excluded until it emits `prompt_evaluated` events.
+- `passive_risk_prompts`: required Claude/Codex hook prompts with no observed follow-up `memory_search`. OpenCode is excluded until it emits `prompt_evaluated` events.
 - `exact_project_searches`: `memory_search` calls scoped to the active project
   family, such as `codex/memories` or `learning/memories`.
 - `broad_or_unscoped_searches`: broad family or unscoped searches, such as
   `codex/` or an empty source prefix.
-- `by_client`: split between Codex and Claude Code.
+- `by_client`: split between Codex, Claude Code, and OpenCode where event types are available. OpenCode currently contributes `tool_call` events only.
 
-Expected enterprise-ready behavior:
+Expected enterprise-ready behavior for Claude/Codex hook clients:
 
 - `active_search_followup_rate` should be close to 1.0.
 - `passive_risk_prompts` should stay near 0.
@@ -69,9 +69,12 @@ Expected enterprise-ready behavior:
 
 ## Generic MCP Clients
 
-Generic MCP clients do not have Claude Code/Codex prompt hooks, so the server
-cannot know which prompts should have searched. For those clients, use server
-metrics to check actual memory tool usage:
+Generic MCP clients do not have prompt/tool telemetry hooks, so the server
+cannot know which prompts should have searched. OpenCode is not generic MCP-only
+after plugin setup because its plugin provides prompt-time recall context and
+memory tool-call telemetry, but it does not yet log prompt classification events.
+For clients without comparable prompt telemetry, use server metrics to check
+actual memory tool usage:
 
 ```bash
 curl -s -H "X-API-Key: $MEMORIES_API_KEY" \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -349,7 +349,7 @@ Events are emitted non-blocking from the calling thread. The bus maintains a bou
 
 ## 10) Hook System
 
-The automatic memory layer uses 12 shell hooks across 10 Claude Code / Cursor lifecycle events, plus a reduced 5-hook Codex variant layered with MCP + developer instructions:
+The automatic memory layer uses 12 shell hooks across 10 Claude Code / Cursor lifecycle events, a reduced 5-hook Codex variant layered with MCP + developer instructions, and an OpenCode plugin + MCP lifecycle distinct from shell hooks:
 
 | Event | Hook | Purpose |
 |---|---|---|
@@ -367,6 +367,8 @@ The automatic memory layer uses 12 shell hooks across 10 Claude Code / Cursor li
 | `SessionEnd` | `memory-commit.sh` | Final extraction and cleanup |
 
 Codex installs `memory-recall.sh`, `memory-query.sh`, `memory-extract.sh`, `memory-observe.sh`, and `memory-guard.sh` via `~/.codex/hooks.json`; because Codex lacks `PreCompact` and `SessionEnd`, its `Stop` hook samples more transcript context.
+
+OpenCode does not use Claude Code or Codex shell hooks. The installer merges `mcp.memories` and the repo-local plugin path into `~/.config/opencode/opencode.json`; the MCP server runs as a local OpenCode server through `zsh -lc`, sourcing `~/.config/memories/env` before executing `mcp-server/index.js`. The plugin injects prompt-time recall context, searches exact project prefixes first (`opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, `wip/{project}`), and logs active-search telemetry for memory tool calls with `client=opencode`. OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added, but automatic extraction is not enabled by default until reliable OpenCode end-of-turn transcript access is proven.
 
 Hooks share a common library (`_lib.sh`) with logging, health checks, and log rotation. All hooks use guarded `_lib.sh` sourcing with no-op fallbacks for backward compatibility. Response hints use a JSON lookup table (`response-hints.json`) rather than shell case/esac. Hook behavior is configurable via 10 environment variables.
 

--- a/docs/decisions/2026-05-07-opencode-integration.md
+++ b/docs/decisions/2026-05-07-opencode-integration.md
@@ -1,0 +1,25 @@
+# ADR: OpenCode Integration Architecture
+
+**Date:** 2026-05-07
+**Status:** Accepted
+
+## Context
+
+Memories already supports Claude Code, Cursor, Codex, and OpenClaw through client-specific hooks, MCP, or skill flows. OpenCode needs first-class support, but it does not share Claude Code or Codex shell-hook lifecycles.
+
+## Decision
+
+Use OpenCode MCP plus a repo-local OpenCode plugin as the integration boundary.
+
+The installer adds an `--opencode` target that merges `mcp.memories` and the plugin path into `~/.config/opencode/opencode.json`, installs the shared Memories skill under `~/.config/opencode/skills/memories`, and preserves custom user-owned Memories skill/MCP entries unless they carry the Memories OpenCode installer marker.
+
+The plugin provides prompt-time recall context via `experimental.chat.system.transform` and active-search telemetry for memory tool calls via `tool.execute.after`. It searches exact project prefixes first: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, and `wip/{project}`.
+
+Automatic OpenCode extraction is not enabled by default. OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added, but extraction remains gated until reliable OpenCode end-of-turn transcript access is proven.
+
+## Consequences
+
+- OpenCode gains retrieval guidance and MCP access without reusing Claude Code or Codex shell hooks.
+- The installer can safely coexist with existing OpenCode user config because managed entries are marker-scoped.
+- Active-search monitoring can identify OpenCode memory tool usage with `client=opencode`, but OpenCode does not yet contribute prompt classification or follow-up metrics.
+- Extraction parity is deferred until OpenCode exposes a reliable lifecycle point with sufficient transcript context.

--- a/integrations/QUICKSTART-LLM.md
+++ b/integrations/QUICKSTART-LLM.md
@@ -1,6 +1,6 @@
 # Memories — Automatic Memory Layer Setup
 
-> **This document is designed to be fed directly to an LLM (Claude Code, Codex, Cursor, OpenClaw, or any AI coding assistant) so it can set up automatic memory integration for you.**
+> **This document is designed to be fed directly to an LLM (Claude Code, Codex, OpenCode, Cursor, OpenClaw, or any AI coding assistant) so it can set up automatic memory integration for you.**
 
 > **Recommended:** Install via the plugin marketplace: `claude plugins install memories@dk-marketplace`, then run `/memories:setup` to provision the backend. This handles hook installation, settings configuration, and env file creation automatically. The manual steps below are for reference or non-plugin environments.
 
@@ -8,8 +8,8 @@
 
 Memories is a local semantic memory service running at `http://localhost:8900`. This guide sets up automatic memory integrations so your AI assistant:
 
-1. **Retrieves** relevant memories during coding flow (fully automatic with Claude hooks; MCP-guided on Codex/Cursor/OpenClaw)
-2. **Extracts** facts from conversations and stores them automatically (no manual save)
+1. **Retrieves** relevant memories during coding flow (fully automatic with Claude/Codex hooks; plugin-guided on OpenCode; MCP-guided on Cursor/OpenClaw)
+2. **Extracts** facts from conversations and stores them automatically where transcript hooks are available (OpenCode extraction is gated for now)
 3. **Updates** stale memories intelligently using AUDN (Add/Update/Delete/Noop)
 
 After setup, memory works invisibly — the assistant gets context from past sessions automatically.
@@ -363,6 +363,30 @@ Codex will expose `memory_search`, `memory_add`, `memory_delete`, `memory_delete
 
 ---
 
+## Setup for OpenCode
+
+OpenCode uses Memories through MCP plus OpenCode plugin hooks. It does not use Claude Code or Codex shell hooks.
+
+### Run the installer
+
+```bash
+cd ~/projects/memories
+npm --prefix ./mcp-server install
+./integrations/claude-code/install.sh --opencode
+```
+
+The installer will:
+1. Merge `mcp.memories` into `~/.config/opencode/opencode.json`
+2. Configure a local OpenCode MCP server using `zsh -lc` to source `~/.config/memories/env` and run `mcp-server/index.js`
+3. Register the repo-local plugin path `integrations/opencode/plugin/memories.js`
+4. Install `~/.config/opencode/skills/memories/SKILL.md` with marker-safe behavior that preserves an existing unmarked skill directory
+
+The plugin reads `~/.config/memories/env` by default for `MEMORIES_URL`, `MEMORIES_API_KEY`, `MEMORIES_ACTIVE_SEARCH_LOG`, and `MEMORIES_ACTIVE_SEARCH_METRICS`. It provides prompt-time recall context and active-search `tool_call` telemetry for memory tool calls with `client=opencode`, writing to `~/.config/memories/active-search.jsonl` unless metrics are disabled. It searches exact project prefixes first in this order: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, `wip/{project}`.
+
+OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added. The first implementation does not auto-extract by default because automatic extraction remains gated until reliable OpenCode end-of-turn transcript access is proven.
+
+---
+
 ## Setup for OpenClaw
 
 OpenClaw doesn't have hooks, so memory is agent-initiated via the skill. Update the skill file:
@@ -472,6 +496,7 @@ curl -s https://memory.yourdomain.com/health   # prod
 |--------|--------------------------|-------|
 | Claude Code | Yes | Uses hook scripts that read `backends.yaml` |
 | Codex | Yes | Codex-specific hook scripts that read `backends.yaml` |
+| OpenCode | No | First implementation uses MCP plus plugin prompt recall and memory-tool telemetry, not shell-hook routing |
 | Cursor | Yes | Same hook scripts via Third-party skills |
 | OpenClaw | Not yet | Uses skill-based extraction, not hooks |
 
@@ -504,7 +529,17 @@ curl -s https://memory.yourdomain.com/health   # prod
 
 Codex uses `~/.codex/hooks.json` for hooks, `~/.codex/settings.json` for tool permissions, and `~/.codex/config.toml` for MCP + developer instructions. The legacy `memory-codex-notify.sh` (config.toml notify hook) is preserved for backward compatibility but superseded by native hooks.
 
-**Token cost:** ~1500 tokens/turn injected context (retrieval). Extraction is async and free if using Ollama, ~$0.001/turn with API providers.
+### OpenCode
+
+| Mechanism | Sync? | What It Does |
+|-----------|-------|--------------|
+| `experimental.chat.system.transform` plugin hook | Sync | Injects recall guidance and recent project memories |
+| `tool.execute.after` plugin hook | Async | Logs memory MCP tool telemetry with `client=opencode` |
+| `mcp.memories` in `~/.config/opencode/opencode.json` | — | Exposes Memories MCP tools through local OpenCode MCP |
+
+OpenCode source-prefix policy searches exact project scopes: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, and `wip/{project}`. OpenCode extraction is not automatic yet.
+
+**Claude/Codex hook token cost:** ~1500 tokens/turn injected context (retrieval). Extraction is async and free if using Ollama, ~$0.001/turn with API providers. OpenCode extraction is not automatic in the first implementation.
 
 ---
 
@@ -531,9 +566,9 @@ Codex uses `~/.codex/hooks.json` for hooks, `~/.codex/settings.json` for tool pe
 |----------|---------|-------------|
 | `MEMORIES_URL` | `http://localhost:8900` | Memories service URL |
 | `MEMORIES_API_KEY` | (empty) | API key for Memories service auth |
-| `MEMORIES_ENV_FILE` | `~/.config/memories/env` | Hook env file path for Claude/Codex hooks and OpenClaw QMD sync snippets |
-| `MEMORIES_SOURCE_PREFIXES` | client-specific | Retrieval prefixes for settings-based hooks. Defaults to `claude-code/{project},codex/{project},learning/{project},wip/{project}` for Claude/Cursor and `codex/{project},claude-code/{project},learning/{project},wip/{project}` under `~/.codex/hooks/memory`. |
-| `MEMORIES_EXTRACT_SOURCE` | client-specific | Extraction source for settings-based hooks. Defaults to `claude-code/{project}` for Claude/Cursor and `codex/{project}` under `~/.codex/hooks/memory`. |
+| `MEMORIES_ENV_FILE` | `~/.config/memories/env` | Hook env file path for Claude/Codex hooks and OpenClaw QMD sync snippets; OpenCode MCP sources this file via `zsh -lc` |
+| `MEMORIES_SOURCE_PREFIXES` | client-specific | Retrieval prefixes for settings-based hooks. Defaults to `claude-code/{project},codex/{project},learning/{project},wip/{project}` for Claude/Cursor and `codex/{project},claude-code/{project},learning/{project},wip/{project}` under `~/.codex/hooks/memory`. OpenCode plugin recall uses `opencode/{project},claude-code/{project},codex/{project},learning/{project},wip/{project}`. |
+| `MEMORIES_EXTRACT_SOURCE` | client-specific | Extraction source for settings-based hooks. Defaults to `claude-code/{project}` for Claude/Cursor and `codex/{project}` under `~/.codex/hooks/memory`. OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added. |
 | `MEMORIES_SOURCE_PREFIX` | `codex` | Legacy notify-hook prefix used only by `memory-codex-notify.sh` |
 | `MEMORIES_SOURCE` | (empty) | Legacy notify-hook full source override used only by `memory-codex-notify.sh` |
 | `EXTRACT_PROVIDER` | (none) | `anthropic`, `openai`, `chatgpt-subscription`, `ollama`, or empty to disable |
@@ -629,17 +664,15 @@ This enables strict add-only fallback writes (no AUDN update/delete behavior), i
 ### Remove all integrations
 
 ```bash
-# Remove Claude hooks
-rm -rf ~/.claude/hooks/memory/
+# Remove Claude hooks/config installed by the Memories installer
+./integrations/claude-code/install.sh --claude --uninstall
 
-# Remove Codex hooks
-rm -rf ~/.codex/hooks/memory/
+# Remove Codex hooks/config installed by the Memories installer
+./integrations/claude-code/install.sh --codex --uninstall
 
-# Remove Codex hook entries from ~/.codex/hooks.json (or delete the file if only Memories hooks exist)
-
-# Remove Codex config entries from ~/.codex/config.toml:
-# - [mcp_servers.memories] section
-# - [mcp_servers.memories.env] section
+# Remove OpenCode mcp/plugin entries and marker-managed skill files.
+# Existing unmarked ~/.config/opencode/skills/memories content is preserved.
+./integrations/claude-code/install.sh --opencode --uninstall
 
 # Remove env vars from hook/repo env files
 # Edit ~/.config/memories/env and remove MEMORIES_URL/MEMORIES_API_KEY/MEMORIES_SOURCE_PREFIXES/MEMORIES_EXTRACT_SOURCE
@@ -665,6 +698,9 @@ jq '.hooks' ~/.codex/hooks.json
 
 # Codex: test recall hook manually
 echo '{"cwd": "/Users/you/project", "source": "startup"}' | bash ~/.codex/hooks/memory/memory-recall.sh
+
+# OpenCode: check MCP/plugin config
+jq '.mcp.memories, .plugin' ~/.config/opencode/opencode.json
 ```
 
 ### Extraction returning 501

--- a/integrations/claude-code/install.sh
+++ b/integrations/claude-code/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # install.sh — installer for Memories automatic integrations
-# Usage: ./install.sh [--auto] [--claude] [--codex] [--cursor] [--openclaw] [--uninstall] [--dry-run]
+# Usage: ./install.sh [--auto] [--claude] [--codex] [--cursor] [--opencode] [--openclaw] [--uninstall] [--dry-run]
 set -euo pipefail
 
 # Colors
@@ -15,6 +15,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOKS_SRC="$SCRIPT_DIR/hooks"
 OPENCLAW_SKILL_SRC="$REPO_ROOT/integrations/openclaw-skill.md"
 CODEX_HOOKS_SRC="$REPO_ROOT/integrations/codex/hooks"
+OPENCODE_SKILL_SRC="$REPO_ROOT/plugin/skills/memories/SKILL.md"
+OPENCODE_PLUGIN_SRC="$REPO_ROOT/integrations/opencode/plugin/memories.js"
 
 READONLY_MCP_TOOLS='["mcp__memories__memory_search","mcp__memories__memory_list","mcp__memories__memory_count","mcp__memories__memory_stats","mcp__memories__memory_is_novel","mcp__memories__memory_is_useful","mcp__memories__memory_conflicts"]'
 
@@ -25,6 +27,7 @@ CODEX_DEV_INSTR_MARKER="Memories Codex developer instructions"
 TARGET_CLAUDE=false
 TARGET_CODEX=false
 TARGET_CURSOR=false
+TARGET_OPENCODE=false
 TARGET_OPENCLAW=false
 EXPLICIT_TARGETS=false
 AUTO_DETECT=true
@@ -43,6 +46,7 @@ Options:
   --claude     Install Claude Code hooks + MCP
   --codex      Install Codex integration (settings hooks + MCP)
   --cursor     Install Cursor hooks + MCP
+  --opencode   Install OpenCode MCP, plugin, and Memories skill
   --openclaw   Install OpenClaw skill
   --uninstall  Remove installed files for selected targets
   --dry-run    Print detected/selected targets and exit
@@ -75,6 +79,11 @@ for arg in "$@"; do
       EXPLICIT_TARGETS=true
       AUTO_DETECT=false
       ;;
+    --opencode)
+      TARGET_OPENCODE=true
+      EXPLICIT_TARGETS=true
+      AUTO_DETECT=false
+      ;;
     --openclaw)
       TARGET_OPENCLAW=true
       EXPLICIT_TARGETS=true
@@ -102,6 +111,7 @@ detect_targets() {
   TARGET_CLAUDE=false
   TARGET_CODEX=false
   TARGET_CURSOR=false
+  TARGET_OPENCODE=false
   TARGET_OPENCLAW=false
 
   if [ -d "$HOME/.claude" ] || [ -f "$HOME/.claude/settings.json" ]; then
@@ -113,6 +123,9 @@ detect_targets() {
   if [ -d "$HOME/.cursor" ]; then
     TARGET_CURSOR=true
   fi
+  if [ -d "$HOME/.config/opencode" ] || [ -f "$HOME/.config/opencode/opencode.json" ]; then
+    TARGET_OPENCODE=true
+  fi
   if [ -d "$HOME/.openclaw" ] || [ -d "$HOME/.openclaw/skills" ]; then
     TARGET_OPENCLAW=true
   fi
@@ -123,7 +136,7 @@ if [ "$AUTO_DETECT" = true ] && [ "$EXPLICIT_TARGETS" = false ]; then
 fi
 
 # Fallback for first-time setup
-if [ "$TARGET_CLAUDE" = false ] && [ "$TARGET_CODEX" = false ] && [ "$TARGET_CURSOR" = false ] && [ "$TARGET_OPENCLAW" = false ]; then
+if [ "$TARGET_CLAUDE" = false ] && [ "$TARGET_CODEX" = false ] && [ "$TARGET_CURSOR" = false ] && [ "$TARGET_OPENCODE" = false ] && [ "$TARGET_OPENCLAW" = false ]; then
   TARGET_CLAUDE=true
 fi
 
@@ -131,6 +144,7 @@ target_list=()
 [ "$TARGET_CLAUDE" = true ] && target_list+=("claude")
 [ "$TARGET_CODEX" = true ] && target_list+=("codex")
 [ "$TARGET_CURSOR" = true ] && target_list+=("cursor")
+[ "$TARGET_OPENCODE" = true ] && target_list+=("opencode")
 [ "$TARGET_OPENCLAW" = true ] && target_list+=("openclaw")
 TARGETS_CSV="$(IFS=, ; echo "${target_list[*]}")"
 
@@ -239,6 +253,36 @@ remove_mcp_json_target() {
   echo -e "  ${GREEN}[OK]${NC} Removed $label MCP 'memories' from $settings_file"
 }
 
+remove_opencode_target() {
+  local config_file="$HOME/.config/opencode/opencode.json"
+  local skill_dir="$HOME/.config/opencode/skills/memories"
+  local skill_marker="$skill_dir/.memories-installer-managed"
+
+  if [ -f "$config_file" ]; then
+    local cleaned
+    cleaned=$(jq --arg plugin_suffix "/integrations/opencode/plugin/memories.js" '
+      if .mcp.memories.environment.MEMORIES_MANAGED_BY == "memories-opencode-installer"
+      then del(.mcp.memories)
+      else . end
+      | if .mcp == {} then del(.mcp) else . end
+      | if (.plugin? | type) == "array" then
+          .plugin = (.plugin | map(select((type == "string" and endswith($plugin_suffix)) | not)))
+          | if .plugin == [] then del(.plugin) else . end
+        else . end
+    ' "$config_file")
+    echo "$cleaned" > "$config_file"
+    echo -e "  ${GREEN}[OK]${NC} Removed OpenCode Memories config from $config_file"
+  fi
+
+  if [ -f "$skill_marker" ]; then
+    remove_target "OpenCode skill" "$skill_dir"
+  elif [ -d "$skill_dir" ]; then
+    echo -e "  ${YELLOW}[SKIP]${NC} OpenCode skill exists without installer marker, preserving: $skill_dir"
+  else
+    echo -e "  ${YELLOW}[WARN]${NC} Not found (OpenCode skill): $skill_dir"
+  fi
+}
+
 if [ "$UNINSTALL" = true ]; then
   echo -e "${YELLOW}Uninstalling selected targets...${NC}"
 
@@ -280,6 +324,10 @@ if [ "$UNINSTALL" = true ]; then
 
   if [ "$TARGET_OPENCLAW" = true ]; then
     remove_target "OpenClaw skill" "$HOME/.openclaw/skills/memories"
+  fi
+
+  if [ "$TARGET_OPENCODE" = true ]; then
+    remove_opencode_target
   fi
 
   echo ""
@@ -477,6 +525,52 @@ install_openclaw_target() {
   echo -e "  ${GREEN}[OK]${NC} Installed OpenClaw skill: $skill_dir/SKILL.md"
 }
 
+install_opencode_target() {
+  local config_file="$HOME/.config/opencode/opencode.json"
+  local skill_dir="$HOME/.config/opencode/skills/memories"
+  local skill_marker="$skill_dir/.memories-installer-managed"
+  local mcp_path="$REPO_ROOT/mcp-server/index.js"
+
+  mkdir -p "$(dirname "$config_file")"
+  if [ ! -f "$config_file" ]; then
+    echo '{}' > "$config_file"
+  fi
+
+  local merged
+  merged=$(jq --arg mcp_path "$mcp_path" \
+              --arg plugin_path "$OPENCODE_PLUGIN_SRC" \
+              --arg plugin_suffix "/integrations/opencode/plugin/memories.js" '
+    if .mcp.memories then . else
+      .mcp.memories = {
+        type: "local",
+        enabled: true,
+        timeout: 10000,
+        environment: {MEMORIES_MANAGED_BY: "memories-opencode-installer"},
+        command: [
+          "zsh",
+          "-lc",
+          ("set -a; [ -f \"$HOME/.config/memories/env\" ] && . \"$HOME/.config/memories/env\"; set +a; exec node \"" + $mcp_path + "\"")
+        ]
+      }
+    end
+    | .plugin = (((if (.plugin? | type) == "array" then .plugin else [] end)
+        | map(select((type == "string" and endswith($plugin_suffix)) | not))
+        + [$plugin_path])
+      | reduce .[] as $item ([]; if index($item) then . else . + [$item] end))
+  ' "$config_file")
+  echo "$merged" > "$config_file"
+  echo -e "  ${GREEN}[OK]${NC} Merged OpenCode MCP and plugin config into $config_file"
+
+  if [ -d "$skill_dir" ] && [ ! -f "$skill_marker" ]; then
+    echo -e "  ${YELLOW}[SKIP]${NC} OpenCode skill already exists without installer marker, preserving: $skill_dir"
+  else
+    mkdir -p "$skill_dir"
+    cp "$OPENCODE_SKILL_SRC" "$skill_dir/SKILL.md"
+    echo "managed by Memories OpenCode installer" > "$skill_marker"
+    echo -e "  ${GREEN}[OK]${NC} Installed OpenCode skill: $skill_dir/SKILL.md"
+  fi
+}
+
 install_codex_target() {
   local hook_dir="$HOME/.codex/hooks/memory"
   local codex_hooks_json="$HOME/.codex/hooks.json"
@@ -604,6 +698,10 @@ fi
 
 if [ "$TARGET_OPENCLAW" = true ]; then
   install_openclaw_target
+fi
+
+if [ "$TARGET_OPENCODE" = true ]; then
+  install_opencode_target
 fi
 
 echo ""

--- a/integrations/codex/hooks/_lib.sh
+++ b/integrations/codex/hooks/_lib.sh
@@ -57,14 +57,14 @@ _source_prefix_quality() {
   fi
   if [ -n "$project" ]; then
     case "$source_prefix" in
-      "claude-code/$project"|"claude-code/$project/"*|"codex/$project"|"codex/$project/"*|"learning/$project"|"learning/$project/"*|"wip/$project"|"wip/$project/"*)
+      "claude-code/$project"|"claude-code/$project/"*|"codex/$project"|"codex/$project/"*|"opencode/$project"|"opencode/$project/"*|"learning/$project"|"learning/$project/"*|"wip/$project"|"wip/$project/"*)
         printf 'exact_project'
         return 0
         ;;
     esac
   fi
   case "$source_prefix" in
-    claude-code/|codex/|learning/|wip/|claude-code|codex|learning|wip)
+    claude-code/|codex/|opencode/|learning/|wip/|claude-code|codex|opencode|learning|wip)
       printf 'broad_or_unscoped'
       ;;
     *)

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,51 @@
+# OpenCode Integration
+
+Memories supports OpenCode through OpenCode MCP plus repo-local plugin hooks. This is separate from Claude Code and Codex shell hooks.
+
+## Setup
+
+From the Memories repo root:
+
+```bash
+npm --prefix ./mcp-server install
+./integrations/claude-code/install.sh --opencode
+```
+
+The installer merges config into `~/.config/opencode/opencode.json` and registers:
+
+- `mcp.memories` as a local OpenCode MCP server.
+- A `zsh -lc` command that sources `~/.config/memories/env` and runs `mcp-server/index.js`.
+- The repo-local plugin path `integrations/opencode/plugin/memories.js`.
+- The Memories skill at `~/.config/opencode/skills/memories/SKILL.md`.
+
+Skill installation is marker-safe: an existing unmarked `~/.config/opencode/skills/memories` directory is preserved instead of overwritten.
+
+## Behavior
+
+The first OpenCode implementation provides:
+
+- Prompt-time recall context through `experimental.chat.system.transform`.
+- Exact project-prefix searches in this order: `opencode/{project}`, `claude-code/{project}`, `codex/{project}`, `learning/{project}`, `wip/{project}`.
+- Active-search telemetry for memory MCP tool calls with `client=opencode`.
+
+The plugin reads `~/.config/memories/env` by default for `MEMORIES_URL`, `MEMORIES_API_KEY`, `MEMORIES_ACTIVE_SEARCH_LOG`, and `MEMORIES_ACTIVE_SEARCH_METRICS`. It writes active-search `tool_call` telemetry to `~/.config/memories/active-search.jsonl` by default unless `MEMORIES_ACTIVE_SEARCH_METRICS` is disabled.
+
+Automatic extraction is not enabled by default for OpenCode yet. OpenCode-authored extracted memories should use `opencode/{project}` when extraction is added, but extraction remains gated until reliable OpenCode end-of-turn transcript access is proven.
+
+## Troubleshooting
+
+- Check `~/.config/opencode/opencode.json` for `mcp.memories` and the plugin path.
+- Check `~/.config/memories/env` for `MEMORIES_URL` and optional `MEMORIES_API_KEY`.
+- Confirm the Memories service is running with `curl http://localhost:8900/health`.
+- Confirm MCP server dependencies are installed with `npm --prefix ./mcp-server install`.
+- Active-search telemetry writes to `~/.config/memories/active-search.jsonl` by default unless disabled with `MEMORIES_ACTIVE_SEARCH_METRICS=0`.
+
+## Uninstall
+
+From the Memories repo root:
+
+```bash
+./integrations/claude-code/install.sh --opencode --uninstall
+```
+
+The uninstaller removes OpenCode MCP/plugin entries and marker-managed skill files while preserving existing unmarked `~/.config/opencode/skills/memories` content.

--- a/integrations/opencode/plugin/memories.js
+++ b/integrations/opencode/plugin/memories.js
@@ -1,0 +1,300 @@
+const CLIENT_PREFIXES = ["opencode", "claude-code", "codex", "learning", "wip"];
+
+function basename(value) {
+  return String(value || "")
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .pop();
+}
+
+function projectName(options = {}) {
+  if (typeof options.project === "string" && options.project) return options.project;
+  if (options.project && typeof options.project === "object") {
+    if (options.project.name) return String(options.project.name);
+    if (options.project.worktree) return basename(options.project.worktree);
+  }
+  if (options.worktree) return basename(options.worktree);
+  if (options.directory) return basename(options.directory);
+  if (typeof process !== "undefined" && process.cwd) {
+    return basename(process.cwd()) || "project";
+  }
+  return "project";
+}
+
+function defaultSourcePrefixes(project) {
+  return CLIENT_PREFIXES.map((prefix) => `${prefix}/${project}`);
+}
+
+function defaultExtractSource(project) {
+  return `opencode/${project}`;
+}
+
+function sourcePrefixQuality(sourcePrefix, project) {
+  const value = sourcePrefix || "";
+  if (CLIENT_PREFIXES.some((prefix) => value === `${prefix}/${project}` || value.startsWith(`${prefix}/${project}/`))) {
+    return "exact_project";
+  }
+  if (value === "" || CLIENT_PREFIXES.some((prefix) => value === prefix || value === `${prefix}/`)) {
+    return "broad_or_unscoped";
+  }
+  return "other";
+}
+
+function resultText(result) {
+  return result.text || result.content || result.memory || result.summary || "";
+}
+
+function renderRecallContext({ project, results = [], activeSearchRequired = false } = {}) {
+  const prefixes = defaultSourcePrefixes(project || "project");
+  const lines = ["OpenCode Memories Recall Context"];
+
+  if (activeSearchRequired) {
+    lines.push(
+      "MANDATORY FIRST ACTION: before answering questions about prior decisions, architecture, conventions, deferred work, past bugs, project history, or resumed topics, actively call memory_search with an exact project source_prefix."
+    );
+  }
+
+  lines.push("Candidate exact project searches:");
+  for (const prefix of prefixes) {
+    lines.push(`- Call memory_search with source_prefix="${prefix}".`);
+  }
+  lines.push("memory_get is not a substitute for memory_search; use memory_get only after memory_search returns a specific memory id.");
+
+  if (results.length > 0) {
+    lines.push("Recent recalled memories:");
+    for (const result of results) {
+      const source = result.source ? ` [${result.source}]` : "";
+      const id = result.id === undefined ? "" : `#${result.id} `;
+      lines.push(`- ${id}${resultText(result)}${source}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function timestamp(options = {}) {
+  if (typeof options.now === "function") return options.now();
+  return new Date().toISOString();
+}
+
+function homeDir(options = {}) {
+  if (options.home) return String(options.home);
+  const processEnv = typeof process !== "undefined" ? process.env : {};
+  return processEnv.HOME || "";
+}
+
+function configPath(options = {}, filename) {
+  const path = require("node:path");
+  return path.join(homeDir(options), ".config", "memories", filename);
+}
+
+function readEnvFile(options = {}) {
+  if (options.envFile === false) return {};
+  const envFile = options.envFile || configPath(options, "env");
+  const fs = options.fsImpl || require("node:fs");
+  if (!fs.existsSync(envFile)) return {};
+  const env = {};
+  for (const line of fs.readFileSync(envFile, "utf8").split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)\s*$/);
+    if (!match) continue;
+    env[match[1]] = match[2].replace(/^['"]|['"]$/g, "");
+  }
+  return env;
+}
+
+function metricsDisabled(value) {
+  return ["0", "false", "no", "off"].includes(String(value || "").toLowerCase());
+}
+
+function activeSearchLogPath(options = {}) {
+  if (options.activeSearchLog === false) return "";
+  const env = readEnvFile(options);
+  const processEnv = typeof process !== "undefined" ? process.env : {};
+  if (metricsDisabled(env.MEMORIES_ACTIVE_SEARCH_METRICS || processEnv.MEMORIES_ACTIVE_SEARCH_METRICS)) return "";
+  if (typeof options.activeSearchLog === "function") return options.activeSearchLog;
+  if (options.activeSearchLog) return options.activeSearchLog;
+
+  return env.MEMORIES_ACTIVE_SEARCH_LOG || processEnv.MEMORIES_ACTIVE_SEARCH_LOG || configPath(options, "active-search.jsonl");
+}
+
+function appendTelemetry(record, options = {}) {
+  const activeSearchLog = activeSearchLogPath(options);
+  if (!activeSearchLog) return;
+  if (typeof activeSearchLog === "function") {
+    activeSearchLog(record);
+    return;
+  }
+
+  const fs = options.fsImpl || require("node:fs");
+  const path = require("node:path");
+  fs.mkdirSync(path.dirname(activeSearchLog), { recursive: true });
+  fs.appendFileSync(activeSearchLog, `${JSON.stringify(record)}\n`);
+}
+
+function isMemoryToolName(toolName) {
+  const name = String(toolName || "");
+  return /^memory_/.test(name) || /^mcp__memories__memory_/.test(name) || /^memories[._]memory_/.test(name);
+}
+
+async function observeToolCall(toolName, args = {}, sessionID, options = {}) {
+  if (!isMemoryToolName(toolName)) return undefined;
+  const project = projectName(options);
+  const sourcePrefix = args.source_prefix || args.sourcePrefix || "";
+  const record = {
+    client: "opencode",
+    event: "tool_call",
+    tool_name: toolName,
+    source_prefix: sourcePrefix,
+    source_prefix_quality: sourcePrefixQuality(sourcePrefix, project),
+    session_id: sessionID || args.sessionID || args.session_id || "",
+    project,
+    timestamp: timestamp(options),
+  };
+  appendTelemetry(record, options);
+  return record;
+}
+
+function memoriesConfig(options = {}) {
+  const env = readEnvFile(options);
+  const processEnv = typeof process !== "undefined" ? process.env : {};
+  return {
+    url: options.memoriesUrl || env.MEMORIES_URL || processEnv.MEMORIES_URL || "",
+    apiKey: options.memoriesApiKey || env.MEMORIES_API_KEY || processEnv.MEMORIES_API_KEY || "",
+  };
+}
+
+function lastUserText(input = {}) {
+  const messages = Array.isArray(input.messages) ? input.messages : [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const text = messageUserText(messages[index]);
+    if (text) return text;
+  }
+  return "";
+}
+
+function partText(part) {
+  if (typeof part === "string") return part;
+  if (!part || typeof part !== "object") return "";
+  return String(part.text || part.content || "");
+}
+
+function messageUserText(message) {
+  if (!message || typeof message !== "object") return "";
+  const role = message.role || (message.info && message.info.role);
+  if (role !== "user") return "";
+  if (message.content) return String(message.content).trim();
+  if (Array.isArray(message.parts)) return message.parts.map(partText).join(" ").trim();
+  return "";
+}
+
+async function queryFromSessionMessages(input = {}, options = {}) {
+  const client = options.client;
+  if (!input.sessionID || !client || !client.session || typeof client.session.messages !== "function") return "";
+  try {
+    const response = await client.session.messages({
+      path: { id: input.sessionID },
+      query: { directory: options.directory },
+    });
+    const messages = Array.isArray(response) ? response : Array.isArray(response && response.data) ? response.data : [];
+    return lastUserText({ messages });
+  } catch (error) {
+    return "";
+  }
+}
+
+async function recallQuery(input = {}, options = {}) {
+  return lastUserText(input) || (await queryFromSessionMessages(input, options));
+}
+
+function normalizeResults(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.results)) return payload.results;
+  if (Array.isArray(payload.memories)) return payload.memories;
+  return [];
+}
+
+function fetchTimeoutMs(options = {}) {
+  const value = options.fetchTimeoutMs ?? options.recallTimeoutMs ?? 1200;
+  return Number.isFinite(Number(value)) ? Number(value) : 1200;
+}
+
+async function fetchPrefixResults(fetchImpl, config, sourcePrefix, query, options = {}) {
+  const timeoutMs = fetchTimeoutMs(options);
+  const controller = typeof AbortController === "function" ? new AbortController() : undefined;
+  const timeout = controller && timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+  try {
+    const response = await fetchImpl(`${config.url.replace(/\/$/, "")}/search`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(config.apiKey ? { "X-API-Key": config.apiKey } : {}),
+      },
+      ...(controller ? { signal: controller.signal } : {}),
+      body: JSON.stringify({ query, source_prefix: sourcePrefix, k: 3 }),
+    });
+    if (!response || response.ok === false) return [];
+    return normalizeResults(await response.json());
+  } catch (error) {
+    return [];
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function fetchRecallResults(input = {}, options = {}) {
+  const fetchImpl = options.fetchImpl || (typeof fetch === "function" ? fetch : undefined);
+  const config = memoriesConfig(options);
+  if (!fetchImpl || !config.url) return [];
+
+  const project = projectName(options);
+  const query = await recallQuery(input, options);
+  if (!query) return [];
+  const batches = await Promise.all(defaultSourcePrefixes(project).map((sourcePrefix) => fetchPrefixResults(fetchImpl, config, sourcePrefix, query, options)));
+  return batches.flat();
+}
+
+function sessionID(input = {}) {
+  return input.sessionID || input.sessionId || input.session_id || "";
+}
+
+function ensureSystemArray(output = {}) {
+  if (Array.isArray(output.system)) return output.system;
+  if (output.system === undefined || output.system === null) {
+    output.system = [];
+    return output.system;
+  }
+  output.system = [String(output.system)];
+  return output.system;
+}
+
+function server(input = {}, options = {}) {
+  const hookOptions = { ...input, ...options };
+  return {
+    "experimental.chat.system.transform": async (hookInput = {}, hookOutput = {}) => {
+      const project = projectName(hookOptions);
+      const results = await fetchRecallResults(hookInput, hookOptions);
+      const context = renderRecallContext({ project, results, activeSearchRequired: true });
+      ensureSystemArray(hookOutput).push(context);
+    },
+    event: async () => {},
+    "tool.execute.after": async (hookInput = {}) => {
+      const toolName = hookInput.tool || hookInput.toolName || hookInput.tool_name || hookInput.name || "";
+      if (!isMemoryToolName(toolName)) return;
+      const args = hookInput.args || hookInput.arguments || hookInput.input || {};
+      await observeToolCall(toolName, args, sessionID(hookInput), hookOptions);
+    },
+  };
+}
+
+server.__test = {
+  projectName,
+  defaultSourcePrefixes,
+  defaultExtractSource,
+  sourcePrefixQuality,
+  renderRecallContext,
+  isMemoryToolName,
+  observeToolCall,
+  fetchRecallResults,
+};
+
+module.exports = { id: "memories", server };

--- a/integrations/opencode/plugin/memories.js
+++ b/integrations/opencode/plugin/memories.js
@@ -148,7 +148,7 @@ async function observeToolCall(toolName, args = {}, sessionID, options = {}) {
     source_prefix_quality: sourcePrefixQuality(sourcePrefix, project),
     session_id: sessionID || args.sessionID || args.session_id || "",
     project,
-    timestamp: timestamp(options),
+    ts: timestamp(options),
   };
   appendTelemetry(record, options);
   return record;
@@ -214,7 +214,7 @@ function normalizeResults(payload) {
 }
 
 function fetchTimeoutMs(options = {}) {
-  const value = options.fetchTimeoutMs ?? options.recallTimeoutMs ?? 1200;
+  const value = options.fetchTimeoutMs ?? 1200;
   return Number.isFinite(Number(value)) ? Number(value) : 1200;
 }
 
@@ -276,7 +276,6 @@ function server(input = {}, options = {}) {
       const context = renderRecallContext({ project, results, activeSearchRequired: true });
       ensureSystemArray(hookOutput).push(context);
     },
-    event: async () => {},
     "tool.execute.after": async (hookInput = {}) => {
       const toolName = hookInput.tool || hookInput.toolName || hookInput.tool_name || hookInput.name || "";
       if (!isMemoryToolName(toolName)) return;

--- a/plugin/hooks/_lib.sh
+++ b/plugin/hooks/_lib.sh
@@ -57,14 +57,14 @@ _source_prefix_quality() {
   fi
   if [ -n "$project" ]; then
     case "$source_prefix" in
-      "claude-code/$project"|"claude-code/$project/"*|"codex/$project"|"codex/$project/"*|"learning/$project"|"learning/$project/"*|"wip/$project"|"wip/$project/"*)
+      "claude-code/$project"|"claude-code/$project/"*|"codex/$project"|"codex/$project/"*|"opencode/$project"|"opencode/$project/"*|"learning/$project"|"learning/$project/"*|"wip/$project"|"wip/$project/"*)
         printf 'exact_project'
         return 0
         ;;
     esac
   fi
   case "$source_prefix" in
-    claude-code/|codex/|learning/|wip/|claude-code|codex|learning|wip)
+    claude-code/|codex/|opencode/|learning/|wip/|claude-code|codex|opencode|learning|wip)
       printf 'broad_or_unscoped'
       ;;
     *)

--- a/plugin/skills/memories/SKILL.md
+++ b/plugin/skills/memories/SKILL.md
@@ -231,13 +231,13 @@ For simple cases (2 clear, novel facts), individual `memory_add` calls are fine.
 
 - **Backend provisioning**: Run `/memories:setup` to check service health, configure extraction providers, and write env files. Use this when entering a project where the Memories backend is not yet reachable.
 - **Auto-memory** handles project conventions and patterns in local files — let it do its job
-- **Session hooks** already provide baseline context at startup — Claude Code / Cursor use the full 12-hook lifecycle, while Codex uses 5 native hooks plus MCP + developer instructions. Don't duplicate that work.
+- **Session hooks and plugins** already provide baseline context where supported — Claude Code / Cursor use the full 12-hook lifecycle, Codex uses 5 native hooks plus MCP + developer instructions, and OpenCode uses MCP plus plugin prompt recall and memory-tool telemetry. Don't duplicate that work.
 - **Hook-injected recall is a starting point, not a substitute for active recall.** If the
   retrieved memories look noisy, low-confidence, or obviously cross-project, run explicit
   `memory_search` calls yourself before answering.
-- **Extraction hooks** already trigger `memory_extract` via HTTP at lifecycle boundaries.
+- **Extraction hooks** already trigger `memory_extract` via HTTP at lifecycle boundaries for clients that support them.
   Claude Code / Cursor use `Stop`, `PreCompact`, and `SessionEnd`; Codex uses a
-  beefier `Stop` hook because it has no compaction/session-end lifecycle events.
+  beefier `Stop` hook because it has no compaction/session-end lifecycle events. OpenCode does not auto-extract by default yet; OpenCode extraction is gated until reliable end-of-turn transcript access is proven.
   The skill triggers extraction *within* a session at natural breakpoints that hooks
   miss — like mid-conversation decision changes or deferred work completions.
 - **Learning skill** captures failure-fix patterns — if both skills apply, the learning skill

--- a/plugins/memories/skills/memories/SKILL.md
+++ b/plugins/memories/skills/memories/SKILL.md
@@ -231,13 +231,13 @@ For simple cases (2 clear, novel facts), individual `memory_add` calls are fine.
 
 - **Backend provisioning**: Run `/memories:setup` to check service health, configure extraction providers, and write env files. Use this when entering a project where the Memories backend is not yet reachable.
 - **Auto-memory** handles project conventions and patterns in local files — let it do its job
-- **Session hooks** already provide baseline context at startup — Claude Code / Cursor use the full 12-hook lifecycle, while Codex uses 5 native hooks plus MCP + developer instructions. Don't duplicate that work.
+- **Session hooks and plugins** already provide baseline context where supported — Claude Code / Cursor use the full 12-hook lifecycle, Codex uses 5 native hooks plus MCP + developer instructions, and OpenCode uses MCP plus plugin prompt recall and memory-tool telemetry. Don't duplicate that work.
 - **Hook-injected recall is a starting point, not a substitute for active recall.** If the
   retrieved memories look noisy, low-confidence, or obviously cross-project, run explicit
   `memory_search` calls yourself before answering.
-- **Extraction hooks** already trigger `memory_extract` via HTTP at lifecycle boundaries.
+- **Extraction hooks** already trigger `memory_extract` via HTTP at lifecycle boundaries for clients that support them.
   Claude Code / Cursor use `Stop`, `PreCompact`, and `SessionEnd`; Codex uses a
-  beefier `Stop` hook because it has no compaction/session-end lifecycle events.
+  beefier `Stop` hook because it has no compaction/session-end lifecycle events. OpenCode does not auto-extract by default yet; OpenCode extraction is gated until reliable end-of-turn transcript access is proven.
   The skill triggers extraction *within* a session at natural breakpoints that hooks
   miss — like mid-conversation decision changes or deferred work completions.
 - **Learning skill** captures failure-fix patterns — if both skills apply, the learning skill

--- a/tests/test_active_search_metrics.py
+++ b/tests/test_active_search_metrics.py
@@ -117,3 +117,46 @@ def test_load_events_skips_invalid_jsonl(tmp_path: Path) -> None:
     log.write_text('{"event":"prompt_evaluated"}\nnot-json\n{"event":"tool_call"}\n', encoding="utf-8")
 
     assert [event["event"] for event in load_events(log)] == ["prompt_evaluated", "tool_call"]
+
+
+def test_summarize_attributes_opencode_tool_calls_with_ts_field(tmp_path: Path) -> None:
+    """OpenCode plugin telemetry must use the same `ts` field name as Claude/Codex hooks.
+
+    This guards against a regression where the plugin emitted `timestamp` instead of `ts`,
+    causing matched-prompt analytics to silently drop OpenCode tool_call events.
+    """
+    log = tmp_path / "active-search.jsonl"
+    events = [
+        {
+            "ts": "2026-05-06T12:00:00Z",
+            "event": "prompt_evaluated",
+            "client": "opencode",
+            "session_id": "oc-1",
+            "project": "memories",
+            "prompt_hash": "d" * 64,
+            "active_search_required": True,
+            "candidate_count": 1,
+        },
+        {
+            "ts": "2026-05-06T12:00:15Z",
+            "event": "tool_call",
+            "client": "opencode",
+            "session_id": "oc-1",
+            "project": "memories",
+            "tool_name": "mcp__memories__memory_search",
+            "source_prefix": "opencode/memories",
+            "source_prefix_quality": "exact_project",
+        },
+    ]
+    log.write_text("\n".join(json.dumps(event) for event in events), encoding="utf-8")
+
+    summary = summarize_events(load_events(log), followup_window_seconds=60)
+
+    assert summary["memory_search_calls"] == 1
+    assert summary["exact_project_searches"] == 1
+    assert summary["by_client"]["opencode"]["memory_search_calls"] == 1
+    assert summary["by_client"]["opencode"]["exact_project_searches"] == 1
+    assert summary["by_client"]["opencode"]["required_prompts"] == 1
+    assert summary["by_client"]["opencode"]["required_prompts_with_memory_search"] == 1
+    assert summary["by_client"]["opencode"]["passive_risk_prompts"] == 0
+    assert summary["active_search_followup_rate"] == 1.0

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -23,6 +23,14 @@ def _prepare_installer_fixture(tmp_path: Path) -> Path:
         repo_root / "integrations" / "codex",
         dirs_exist_ok=True,
     )
+    opencode_plugin_dir = repo_root / "integrations" / "opencode" / "plugin"
+    opencode_plugin_dir.mkdir(parents=True, exist_ok=True)
+    (opencode_plugin_dir / "memories.js").write_text("// installer test fixture\n")
+    shutil.copytree(
+        REPO_ROOT / "plugin" / "skills" / "memories",
+        repo_root / "plugin" / "skills" / "memories",
+        dirs_exist_ok=True,
+    )
     mcp_dir = repo_root / "mcp-server"
     mcp_dir.mkdir(parents=True, exist_ok=True)
     (mcp_dir / "index.js").write_text("// installer test fixture\n")
@@ -78,19 +86,29 @@ def test_auto_detect_defaults_to_claude_when_no_client_dirs(tmp_path: Path) -> N
 def test_auto_detect_finds_all_supported_targets(tmp_path: Path) -> None:
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".codex").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
     (tmp_path / ".openclaw" / "skills").mkdir(parents=True)
 
     result = _run_installer(tmp_path, "--auto", "--dry-run")
     assert result.returncode == 0
-    assert "targets=claude,codex,openclaw" in result.stdout
+    assert "targets=claude,codex,opencode,openclaw" in result.stdout
+
+
+def test_auto_detect_finds_opencode_target(tmp_path: Path) -> None:
+    (tmp_path / ".config" / "opencode" / "opencode.json").parent.mkdir(parents=True)
+    (tmp_path / ".config" / "opencode" / "opencode.json").write_text("{}")
+
+    result = _run_installer(tmp_path, "--auto", "--dry-run")
+    assert result.returncode == 0
+    assert "targets=opencode" in result.stdout
 
 
 def test_explicit_target_flags_override_auto_detection(tmp_path: Path) -> None:
     (tmp_path / ".claude").mkdir()
 
-    result = _run_installer(tmp_path, "--codex", "--openclaw", "--dry-run", "--uninstall")
+    result = _run_installer(tmp_path, "--codex", "--opencode", "--openclaw", "--dry-run", "--uninstall")
     assert result.returncode == 0
-    assert "targets=codex,openclaw" in result.stdout
+    assert "targets=codex,opencode,openclaw" in result.stdout
     assert "mode=uninstall" in result.stdout
 
 
@@ -163,3 +181,342 @@ def test_codex_install_writes_standalone_hooks_json(tmp_path: Path) -> None:
     assert (hook_dir / "memory-observe.sh").exists()
     assert (hook_dir / "_lib.sh").exists()
     assert (hook_dir / "response-hints.json").exists()
+
+
+def test_opencode_install_writes_mcp_skill_and_plugin_config(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    opencode_dir = home / ".config" / "opencode"
+    opencode_dir.mkdir(parents=True, exist_ok=True)
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "mcp": {"other": {"type": "remote", "enabled": True}},
+                "plugin": ["/tmp/other-plugin.js"],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(
+        home,
+        "--opencode",
+        install_script=install_script,
+        extra_env={"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Skipping extraction provider prompt (no hook targets selected)" in result.stdout
+
+    config = json.loads(opencode_json.read_text())
+    assert config["theme"] == "system"
+    assert config["mcp"]["other"] == {"type": "remote", "enabled": True}
+    assert config["mcp"]["memories"] == {
+        "type": "local",
+        "enabled": True,
+        "timeout": 10000,
+        "environment": {"MEMORIES_MANAGED_BY": "memories-opencode-installer"},
+        "command": [
+            "zsh",
+            "-lc",
+            f"set -a; [ -f \"$HOME/.config/memories/env\" ] && . \"$HOME/.config/memories/env\"; set +a; exec node \"{repo_root}/mcp-server/index.js\"",
+        ],
+    }
+
+    plugin_path = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    assert config["plugin"] == ["/tmp/other-plugin.js", plugin_path]
+    assert (home / ".config" / "opencode" / "skills" / "memories" / "SKILL.md").read_text() == (
+        repo_root / "plugin" / "skills" / "memories" / "SKILL.md"
+    ).read_text()
+    assert (home / ".config" / "opencode" / "skills" / "memories" / ".memories-installer-managed").exists()
+    assert not (home / ".claude" / "hooks" / "memory").exists()
+    assert not (home / ".codex" / "hooks" / "memory").exists()
+
+
+def test_opencode_install_preserves_existing_memories_mcp(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    custom_mcp = {
+        "type": "remote",
+        "enabled": False,
+        "url": "https://memories.example.test/mcp",
+        "headers": {"Authorization": "Bearer custom"},
+    }
+    opencode_dir = home / ".config" / "opencode"
+    opencode_dir.mkdir(parents=True, exist_ok=True)
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "mcp": {"memories": custom_mcp, "other": {"type": "remote"}},
+                "plugin": ["/tmp/other-plugin.js"],
+            }
+        )
+    )
+
+    result = _run_installer(
+        home,
+        "--opencode",
+        install_script=install_script,
+        extra_env={"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config["mcp"]["memories"] == custom_mcp
+    assert config["mcp"]["other"] == {"type": "remote"}
+    assert config["plugin"] == [
+        "/tmp/other-plugin.js",
+        f"{repo_root}/integrations/opencode/plugin/memories.js",
+    ]
+    assert (home / ".config" / "opencode" / "skills" / "memories" / "SKILL.md").exists()
+
+
+def test_opencode_install_preserves_unmarked_existing_skill(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    opencode_dir = home / ".config" / "opencode"
+    skill_dir = opencode_dir / "skills" / "memories"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    custom_skill = "# Custom OpenCode Memories Skill\n"
+    (skill_dir / "SKILL.md").write_text(custom_skill)
+    (opencode_dir / "opencode.json").write_text(json.dumps({"plugin": []}))
+
+    result = _run_installer(
+        home,
+        "--opencode",
+        install_script=install_script,
+        extra_env={"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OpenCode skill already exists without installer marker" in result.stdout
+    assert (skill_dir / "SKILL.md").read_text() == custom_skill
+    assert not (skill_dir / ".memories-installer-managed").exists()
+    config = json.loads((opencode_dir / "opencode.json").read_text())
+    assert config["plugin"] == [f"{repo_root}/integrations/opencode/plugin/memories.js"]
+
+
+def test_opencode_install_replaces_stale_memories_plugin_path(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    _write_fake_curl(bin_dir)
+
+    stale_plugin = "/old/worktree/integrations/opencode/plugin/memories.js"
+    current_plugin = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    opencode_dir = home / ".config" / "opencode"
+    opencode_dir.mkdir(parents=True, exist_ok=True)
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "plugin": ["/tmp/other-plugin.js", stale_plugin, stale_plugin],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(
+        home,
+        "--opencode",
+        install_script=install_script,
+        extra_env={"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config["plugin"] == ["/tmp/other-plugin.js", current_plugin]
+
+
+def test_opencode_uninstall_removes_only_memories_entries(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    opencode_dir = home / ".config" / "opencode"
+    skill_dir = opencode_dir / "skills" / "memories"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("installed skill\n")
+    (skill_dir / ".memories-installer-managed").write_text("managed by Memories installer\n")
+
+    memories_plugin = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "memories": {
+                        "type": "local",
+                        "enabled": True,
+                        "environment": {"MEMORIES_MANAGED_BY": "memories-opencode-installer"},
+                        "command": [
+                            "zsh",
+                            "-lc",
+                            f"exec node \"{repo_root}/mcp-server/index.js\"",
+                        ],
+                    },
+                    "other": {"type": "remote", "enabled": True},
+                },
+                "plugin": ["/tmp/other-plugin.js", memories_plugin],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(home, "--opencode", "--uninstall", install_script=install_script)
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config == {
+        "mcp": {"other": {"type": "remote", "enabled": True}},
+        "plugin": ["/tmp/other-plugin.js"],
+        "theme": "system",
+    }
+    assert not skill_dir.exists()
+
+
+def test_opencode_uninstall_preserves_unmarked_local_memories_mcp_config(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    opencode_dir = home / ".config" / "opencode"
+    skill_dir = opencode_dir / "skills" / "memories"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    custom_skill = "custom local skill\n"
+    (skill_dir / "SKILL.md").write_text(custom_skill)
+
+    custom_mcp = {
+        "type": "local",
+        "enabled": True,
+        "timeout": 30000,
+        "command": ["node", f"{repo_root}/mcp-server/index.js"],
+        "environment": {"MEMORIES_URL": "https://memories.example.test"},
+    }
+    memories_plugin = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "memories": custom_mcp,
+                    "other": {"type": "remote", "enabled": True},
+                },
+                "plugin": ["/tmp/other-plugin.js", memories_plugin],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(home, "--opencode", "--uninstall", install_script=install_script)
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config == {
+        "mcp": {
+            "memories": custom_mcp,
+            "other": {"type": "remote", "enabled": True},
+        },
+        "plugin": ["/tmp/other-plugin.js"],
+        "theme": "system",
+    }
+    assert skill_dir.exists()
+    assert (skill_dir / "SKILL.md").read_text() == custom_skill
+
+
+def test_opencode_uninstall_preserves_custom_memories_mcp_config(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    opencode_dir = home / ".config" / "opencode"
+    skill_dir = opencode_dir / "skills" / "memories"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    custom_skill = "custom remote skill\n"
+    (skill_dir / "SKILL.md").write_text(custom_skill)
+
+    custom_mcp = {
+        "type": "remote",
+        "enabled": False,
+        "url": "https://memories.example.test/mcp",
+        "headers": {"Authorization": "Bearer custom"},
+    }
+    memories_plugin = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "memories": custom_mcp,
+                    "other": {"type": "remote", "enabled": True},
+                },
+                "plugin": ["/tmp/other-plugin.js", memories_plugin],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(home, "--opencode", "--uninstall", install_script=install_script)
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config == {
+        "mcp": {
+            "memories": custom_mcp,
+            "other": {"type": "remote", "enabled": True},
+        },
+        "plugin": ["/tmp/other-plugin.js"],
+        "theme": "system",
+    }
+    assert skill_dir.exists()
+    assert (skill_dir / "SKILL.md").read_text() == custom_skill
+
+
+def test_opencode_uninstall_removes_stale_memories_plugin_paths(tmp_path: Path) -> None:
+    install_script = _prepare_installer_fixture(tmp_path)
+    repo_root = install_script.parents[2]
+    home = tmp_path / "home"
+    opencode_dir = home / ".config" / "opencode"
+    opencode_dir.mkdir(parents=True, exist_ok=True)
+
+    current_plugin = f"{repo_root}/integrations/opencode/plugin/memories.js"
+    stale_plugin = "/old/worktree/integrations/opencode/plugin/memories.js"
+    opencode_json = opencode_dir / "opencode.json"
+    opencode_json.write_text(
+        json.dumps(
+            {
+                "plugin": [
+                    "/tmp/other-plugin.js",
+                    stale_plugin,
+                    current_plugin,
+                    "/tmp/memories-but-not-opencode.js",
+                ],
+                "theme": "system",
+            }
+        )
+    )
+
+    result = _run_installer(home, "--opencode", "--uninstall", install_script=install_script)
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(opencode_json.read_text())
+    assert config == {
+        "plugin": ["/tmp/other-plugin.js", "/tmp/memories-but-not-opencode.js"],
+        "theme": "system",
+    }

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -140,7 +140,6 @@ console.log(JSON.stringify(Object.keys(hooks).sort()));
     )
 
     assert output == [
-        "event",
         "experimental.chat.system.transform",
         "tool.execute.after",
     ]
@@ -209,7 +208,7 @@ console.log(JSON.stringify(JSON.parse(line)));
         "source_prefix_quality": "exact_project",
         "session_id": "sess-1",
         "project": "demo",
-        "timestamp": "2026-05-06T00:00:00.000Z",
+        "ts": "2026-05-06T00:00:00.000Z",
     }
 
 

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -1,0 +1,498 @@
+"""Tests for the OpenCode Memories plugin runtime helpers."""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = REPO_ROOT / "integrations" / "opencode" / "plugin" / "memories.js"
+
+
+def _run_node(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _plugin_import() -> str:
+    return f"""
+import {{ pathToFileURL }} from 'node:url';
+const imported = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const pluginModule = imported.default || imported;
+const server = pluginModule.server || imported.server;
+const helpers = server.__test;
+"""
+
+
+def _node_json(script: str) -> object:
+    result = _run_node(script)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_opencode_default_prefixes_include_cross_client_project_scope() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify(helpers.defaultSourcePrefixes('demo')));
+"""
+    )
+
+    assert output == [
+        "opencode/demo",
+        "claude-code/demo",
+        "codex/demo",
+        "learning/demo",
+        "wip/demo",
+    ]
+
+
+def test_default_extract_source_uses_opencode_project_prefix() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify(helpers.defaultExtractSource('demo')));
+"""
+    )
+
+    assert output == "opencode/demo"
+
+
+def test_source_prefix_quality_classifies_exact_broad_and_other() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const prefixes = [
+  'opencode/demo',
+  'opencode/demo/session',
+  'claude-code/demo',
+  'codex/demo',
+  'learning/demo',
+  'wip/demo',
+  '',
+  'opencode',
+  'opencode/',
+  'claude-code',
+  'claude-code/',
+  'codex',
+  'codex/',
+  'learning',
+  'learning/',
+  'wip',
+  'wip/',
+  'other/demo',
+  'opencode/other',
+];
+console.log(JSON.stringify(prefixes.map((prefix) => [prefix, helpers.sourcePrefixQuality(prefix, 'demo')])));
+"""
+    )
+
+    assert dict(output) == {
+        "opencode/demo": "exact_project",
+        "opencode/demo/session": "exact_project",
+        "claude-code/demo": "exact_project",
+        "codex/demo": "exact_project",
+        "learning/demo": "exact_project",
+        "wip/demo": "exact_project",
+        "": "broad_or_unscoped",
+        "opencode": "broad_or_unscoped",
+        "opencode/": "broad_or_unscoped",
+        "claude-code": "broad_or_unscoped",
+        "claude-code/": "broad_or_unscoped",
+        "codex": "broad_or_unscoped",
+        "codex/": "broad_or_unscoped",
+        "learning": "broad_or_unscoped",
+        "learning/": "broad_or_unscoped",
+        "wip": "broad_or_unscoped",
+        "wip/": "broad_or_unscoped",
+        "other/demo": "other",
+        "opencode/other": "other",
+    }
+
+
+def test_render_recall_context_uses_active_search_language() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify(helpers.renderRecallContext({ project: 'demo', results: [], activeSearchRequired: true })));
+"""
+    )
+
+    assert "MANDATORY FIRST ACTION" in output
+    assert 'memory_search' in output
+    assert 'source_prefix="opencode/demo"' in output
+    assert 'source_prefix="claude-code/demo"' in output
+    assert "memory_get is not a substitute for memory_search" in output
+
+
+def test_plugin_exports_expected_hooks() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const hooks = server({}, { project: 'demo' });
+console.log(JSON.stringify(Object.keys(hooks).sort()));
+"""
+    )
+
+    assert output == [
+        "event",
+        "experimental.chat.system.transform",
+        "tool.execute.after",
+    ]
+
+
+def test_plugin_top_level_exports_only_server() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify(Object.keys(pluginModule).sort()));
+"""
+    )
+
+    assert output == ["id", "server"]
+
+
+def test_project_name_handles_opencode_project_object() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify([
+  helpers.projectName({ project: { worktree: '/tmp/my-project' } }),
+  helpers.projectName({ directory: '/tmp/my-project' }),
+  helpers.projectName({ project: { name: 'named-project', worktree: '/tmp/ignored' } }),
+]));
+"""
+    )
+
+    assert output == ["my-project", "my-project", "named-project"]
+
+
+def test_project_name_prefers_worktree_over_directory_subdir() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+console.log(JSON.stringify(helpers.projectName({
+  project: { worktree: '/tmp/my-project' },
+  directory: '/tmp/my-project/subdir',
+})));
+"""
+    )
+
+    assert output == "my-project"
+
+
+def test_tool_telemetry_logs_opencode_client(tmp_path: Path) -> None:
+    log_path = tmp_path / "active-search.jsonl"
+    output = _node_json(
+        _plugin_import()
+        + f"""
+await helpers.observeToolCall('memory_search', {{ source_prefix: 'opencode/demo', query: 'do not log me' }}, 'sess-1', {{
+  project: 'demo',
+  activeSearchLog: {json.dumps(str(log_path))},
+  now: () => '2026-05-06T00:00:00.000Z',
+}});
+const line = (await import('node:fs')).readFileSync({json.dumps(str(log_path))}, 'utf8').trim();
+console.log(JSON.stringify(JSON.parse(line)));
+"""
+    )
+
+    assert output == {
+        "client": "opencode",
+        "event": "tool_call",
+        "tool_name": "memory_search",
+        "source_prefix": "opencode/demo",
+        "source_prefix_quality": "exact_project",
+        "session_id": "sess-1",
+        "project": "demo",
+        "timestamp": "2026-05-06T00:00:00.000Z",
+    }
+
+
+def test_tool_after_hook_logs_real_opencode_tool_name(tmp_path: Path) -> None:
+    log_path = tmp_path / "active-search.jsonl"
+    output = _node_json(
+        _plugin_import()
+        + f"""
+const hooks = server({{}}, {{
+  project: 'demo',
+  activeSearchLog: {json.dumps(str(log_path))},
+  now: () => '2026-05-06T00:00:00.000Z',
+}});
+await hooks['tool.execute.after']({{ tool: 'memory_search', sessionID: 'sess-3', args: {{ source_prefix: 'opencode/demo' }} }}, {{}});
+const line = (await import('node:fs')).readFileSync({json.dumps(str(log_path))}, 'utf8').trim();
+console.log(JSON.stringify(JSON.parse(line)));
+"""
+    )
+
+    assert output["tool_name"] == "memory_search"
+    assert output["session_id"] == "sess-3"
+    assert output["source_prefix"] == "opencode/demo"
+
+
+def test_tool_after_hook_logs_memories_mcp_tool_name(tmp_path: Path) -> None:
+    log_path = tmp_path / "active-search.jsonl"
+    output = _node_json(
+        _plugin_import()
+        + f"""
+const hooks = server({{}}, {{
+  project: 'demo',
+  activeSearchLog: {json.dumps(str(log_path))},
+  now: () => '2026-05-06T00:00:00.000Z',
+}});
+await hooks['tool.execute.after']({{ tool: 'mcp__memories__memory_search', sessionID: 'sess-4', args: {{ source_prefix: 'opencode/demo' }} }}, {{}});
+const line = (await import('node:fs')).readFileSync({json.dumps(str(log_path))}, 'utf8').trim();
+console.log(JSON.stringify(JSON.parse(line)));
+"""
+    )
+
+    assert output["tool_name"] == "mcp__memories__memory_search"
+    assert output["session_id"] == "sess-4"
+
+
+def test_non_memory_tool_does_not_write_default_telemetry(tmp_path: Path) -> None:
+    log_path = tmp_path / "active-search.jsonl"
+    output = _node_json(
+        _plugin_import()
+        + f"""
+const fs = await import('node:fs');
+const hooks = server({{}}, {{ project: 'demo', activeSearchLog: {json.dumps(str(log_path))} }});
+await hooks['tool.execute.after']({{ tool: 'bash', sessionID: 'sess', args: {{}} }}, {{}});
+console.log(JSON.stringify(fs.existsSync({json.dumps(str(log_path))})));
+"""
+    )
+
+    assert output is False
+
+
+def test_plugin_does_not_register_extraction_hook_by_default() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const hooks = server({}, { project: 'demo' });
+console.log(JSON.stringify({ keys: Object.keys(hooks).sort(), source: server.toString() }));
+"""
+    )
+
+    assert "experimental.text.complete" not in output["keys"]
+    assert "experimental.session.compacting" not in output["keys"]
+    assert "memory_extract" not in output["source"]
+
+
+def test_transform_appends_recall_context_without_telemetry_text_leak(tmp_path: Path) -> None:
+    log_path = tmp_path / "active-search.jsonl"
+    output = _node_json(
+        _plugin_import()
+        + f"""
+const requests = [];
+const fetchImpl = async (url, init) => {{
+  requests.push({{ url, headers: init.headers }});
+  return {{
+    ok: true,
+    json: async () => ({{ results: [{{ id: 7, text: 'memory-secret', source: 'opencode/demo' }}] }}),
+  }};
+}};
+const hooks = server({{}}, {{
+  project: 'demo',
+  fetchImpl,
+  memoriesUrl: 'http://memories.local',
+  memoriesApiKey: 'test-key',
+  activeSearchLog: {json.dumps(str(log_path))},
+  now: () => '2026-05-06T00:00:00.000Z',
+}});
+const hookInput = {{
+  messages: [{{ role: 'user', content: 'prompt-secret' }}],
+  sessionID: 'sess-2',
+}};
+const hookOutput = {{ system: ['base system'] }};
+await hooks['experimental.chat.system.transform'](hookInput, hookOutput);
+let log = '';
+try {{ log = (await import('node:fs')).readFileSync({json.dumps(str(log_path))}, 'utf8'); }} catch (error) {{}}
+console.log(JSON.stringify({{ system: hookOutput.system, log, requests }}));
+"""
+    )
+
+    assert isinstance(output["system"], list)
+    assert output["system"][0] == "base system"
+    assert "OpenCode Memories Recall Context" in output["system"][1]
+    assert 'source_prefix="opencode/demo"' in output["system"][1]
+    assert "memory-secret" in output["system"][1]
+    assert "prompt-secret" not in output["log"]
+    assert "memory-secret" not in output["log"]
+    assert output["requests"]
+    assert all(request["url"].endswith("/search") for request in output["requests"])
+    assert all(request["headers"]["X-API-Key"] == "test-key" for request in output["requests"])
+
+
+def test_transform_reads_default_env_file_under_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    env_dir = home / ".config" / "memories"
+    env_dir.mkdir(parents=True)
+    (env_dir / "env").write_text(
+        "MEMORIES_URL=http://env-memories.local\nMEMORIES_API_KEY=env-key\n",
+        encoding="utf-8",
+    )
+
+    output = _node_json(
+        _plugin_import()
+        + f"""
+const requests = [];
+const fetchImpl = async (url, init) => {{
+  requests.push({{ url, headers: init.headers }});
+  return {{ ok: true, json: async () => ({{ results: [] }}) }};
+}};
+const hooks = server({{}}, {{ project: 'demo', home: {json.dumps(str(home))}, fetchImpl }});
+await hooks['experimental.chat.system.transform']({{ messages: [{{ role: 'user', content: 'remembered setup' }}] }}, {{ system: [] }});
+console.log(JSON.stringify(requests));
+"""
+    )
+
+    assert output
+    assert all(request["url"].startswith("http://env-memories.local/") for request in output)
+    assert all(request["headers"]["X-API-Key"] == "env-key" for request in output)
+
+
+def test_observe_tool_call_writes_default_active_search_log_under_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    log_path = home / ".config" / "memories" / "active-search.jsonl"
+
+    output = _node_json(
+        _plugin_import()
+        + f"""
+await helpers.observeToolCall('memory_search', {{ source_prefix: 'opencode/demo' }}, 'sess-default-log', {{
+  project: 'demo',
+  home: {json.dumps(str(home))},
+  now: () => '2026-05-06T00:00:00.000Z',
+}});
+const fs = await import('node:fs');
+const line = fs.readFileSync({json.dumps(str(log_path))}, 'utf8').trim();
+console.log(JSON.stringify(JSON.parse(line)));
+"""
+    )
+
+    assert output["client"] == "opencode"
+    assert output["event"] == "tool_call"
+    assert output["tool_name"] == "memory_search"
+    assert output["session_id"] == "sess-default-log"
+    assert output["project"] == "demo"
+
+
+def test_active_search_metrics_zero_in_default_env_disables_default_log(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    env_dir = home / ".config" / "memories"
+    env_dir.mkdir(parents=True)
+    (env_dir / "env").write_text("MEMORIES_ACTIVE_SEARCH_METRICS=0\n", encoding="utf-8")
+    log_path = env_dir / "active-search.jsonl"
+
+    output = _node_json(
+        _plugin_import()
+        + f"""
+await helpers.observeToolCall('memory_search', {{ source_prefix: 'opencode/demo' }}, 'sess-disabled', {{
+  project: 'demo',
+  home: {json.dumps(str(home))},
+}});
+const fs = await import('node:fs');
+console.log(JSON.stringify(fs.existsSync({json.dumps(str(log_path))})));
+"""
+    )
+
+    assert output is False
+
+
+def test_transform_degrades_to_context_when_fetch_throws() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const fetchImpl = async () => { throw new Error('network down'); };
+const hooks = server({}, { project: 'demo', fetchImpl, memoriesUrl: 'http://memories.local' });
+const hookOutput = { system: [] };
+await hooks['experimental.chat.system.transform']({ messages: [{ role: 'user', content: 'prompt-secret' }] }, hookOutput);
+console.log(JSON.stringify(hookOutput.system));
+"""
+    )
+
+    assert len(output) == 1
+    assert "OpenCode Memories Recall Context" in output[0]
+    assert "Recent recalled memories" not in output[0]
+
+
+def test_transform_fetches_latest_user_text_from_opencode_session_messages() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const bodies = [];
+const fetchImpl = async (url, init) => {
+  bodies.push(JSON.parse(init.body));
+  return { ok: true, json: async () => ({ results: [] }) };
+};
+const client = {
+  session: {
+    messages: async (request) => ({
+      data: [
+        { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'ignore me' }] },
+        { info: { role: 'user' }, parts: [{ type: 'text', text: 'latest user question' }] },
+      ],
+      request,
+    }),
+  },
+};
+const hooks = server({ client, project: { worktree: '/tmp/demo' }, directory: '/tmp/demo' }, { fetchImpl, memoriesUrl: 'http://memories.local' });
+const hookOutput = { system: [] };
+await hooks['experimental.chat.system.transform']({ sessionID: 'sess-4', model: {} }, hookOutput);
+console.log(JSON.stringify({ bodies, system: hookOutput.system }));
+"""
+    )
+
+    assert output["bodies"]
+    assert all(body["query"] == "latest user question" for body in output["bodies"])
+    assert "OpenCode Memories Recall Context" in output["system"][0]
+
+
+def test_transform_skips_http_search_when_query_is_empty() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+let fetchCalls = 0;
+const fetchImpl = async () => { fetchCalls += 1; throw new Error('fetch must not be called'); };
+const hooks = server({}, { project: 'demo', fetchImpl, memoriesUrl: 'http://memories.local' });
+const hookOutput = { system: [] };
+await hooks['experimental.chat.system.transform']({ sessionID: 'sess-empty', model: {} }, hookOutput);
+console.log(JSON.stringify({ fetchCalls, system: hookOutput.system }));
+"""
+    )
+
+    assert output["fetchCalls"] == 0
+    assert len(output["system"]) == 1
+    assert "OpenCode Memories Recall Context" in output["system"][0]
+
+
+def test_transform_aborts_slow_recall_fetches_and_appends_context() -> None:
+    output = _node_json(
+        _plugin_import()
+        + """
+const signals = [];
+const fetchImpl = (url, init) => {
+  signals.push(init.signal);
+  return new Promise((resolve, reject) => {
+    init.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+  });
+};
+const hooks = server({}, { project: 'demo', fetchImpl, memoriesUrl: 'http://memories.local', fetchTimeoutMs: 1 });
+const hookOutput = { system: [] };
+await hooks['experimental.chat.system.transform']({ messages: [{ role: 'user', content: 'prompt-secret' }] }, hookOutput);
+console.log(JSON.stringify({
+  signalCount: signals.length,
+  aborted: signals.map((signal) => Boolean(signal && signal.aborted)),
+  system: hookOutput.system,
+}));
+"""
+    )
+
+    assert output["signalCount"] == 5
+    assert all(output["aborted"])
+    assert len(output["system"]) == 1
+    assert "OpenCode Memories Recall Context" in output["system"][0]


### PR DESCRIPTION
## Summary
- Add first-class OpenCode installer support for MCP, repo-local plugin registration, and marker-safe Memories skill installation.
- Add an OpenCode plugin for prompt-time recall context and memory-tool active-search telemetry without enabling automatic extraction yet.
- Document OpenCode lifecycle/setup details and capture the architecture decision in an ADR.

## Testing
- `uv run pytest -q tests/test_codex_plugin.py tests/test_installer.py tests/test_opencode_plugin.py tests/test_claude_memory_hooks.py tests/test_active_search_eval.py tests/test_run_active_search_eval.py` → 77 passed
- `node --check integrations/opencode/plugin/memories.js` → passed
- `bash -n integrations/claude-code/install.sh` → passed
- `git diff --check` → passed
- `opencode debug config` with temp OpenCode config → plugin loaded successfully

## Notes
- Full `uv run pytest -q` currently reports 1396 passed and 1 local failure in `tests/test_mcp_server_stdio.py` because this worktree is missing `mcp-server` Node dependencies (`@modelcontextprotocol/sdk`).
- OpenCode automatic extraction remains gated until reliable end-of-turn transcript access is proven.