### PR TITLE
Write doctrine core: supersede-on-collision, archive-not-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **Write doctrine: corrections supersede instead of being eaten** — `supersede()` now ARCHIVES the original (with `superseded_by` pointer and a `supersedes` link from the new memory) instead of hard-deleting it, and adds the new memory first so a crash can never lose data. New `add_with_doctrine` write path: a colliding write (similarity ≥ dedup threshold) supersedes the blocker when the texts differ materially, skips with the blocking id surfaced when near-identical (≥ `DOCTRINE_IDENTICAL_THRESHOLD`, default 0.97), and never touches pinned blockers. `POST /memory/add` gains `on_duplicate: add|skip|supersede` (legacy behavior unchanged when omitted, but dedup skips now report `blocked_by` + a hint). MCP `memory_add` defaults to `on_duplicate=supersede` — "weight is now 79kg" finally updates "weight is 78kg" instead of being dropped as a duplicate.
+
 ## [5.6.0] - 2026-06-10
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -1328,6 +1328,11 @@ class AddMemoryRequest(BaseModel):
     source: str = Field(..., min_length=1, max_length=500)
     metadata: Optional[dict] = None
     deduplicate: bool = False
+    on_duplicate: Optional[str] = Field(
+        None,
+        pattern="^(add|skip|supersede)$",
+        description="Write doctrine: supersede replaces a colliding memory (keeping it archived with a supersedes link), skip surfaces the blocking id, add bypasses the collision check. Omit for legacy deduplicate behavior.",
+    )
 
 
 class AddBatchRequest(BaseModel):
@@ -2227,8 +2232,27 @@ async def add_memory(request_body: AddMemoryRequest, request: Request):
     """Add a new memory"""
     auth = _get_auth(request)
     _require_write(auth, request_body.source)
-    logger.info("Add memory: source=%s len=%d", request_body.source, len(request_body.text))
+    logger.info(
+        "Add memory: source=%s len=%d on_duplicate=%s",
+        request_body.source, len(request_body.text), request_body.on_duplicate,
+    )
     try:
+        if request_body.on_duplicate:
+            result = memory.add_with_doctrine(
+                text=request_body.text,
+                source=request_body.source,
+                metadata=request_body.metadata,
+                on_duplicate=request_body.on_duplicate,
+            )
+            usage_tracker.log_api_event("add", request_body.source)
+            audit_action = {
+                "added": "memory.created",
+                "superseded": "memory.superseded",
+                "skipped": "memory.add_skipped",
+            }[result["action"]]
+            _audit(request, audit_action, resource_id=str(result.get("id") or result.get("blocked_by") or ""), source=request_body.source)
+            return {"success": True, **result}
+
         ids = memory.add_memories(
             texts=[request_body.text],
             sources=[request_body.source],
@@ -2237,12 +2261,24 @@ async def add_memory(request_body: AddMemoryRequest, request: Request):
         )
         usage_tracker.log_api_event("add", request_body.source)
         result_id = ids[0] if ids else None
-        _audit(request, "memory.created", resource_id=str(result_id or ""), source=request_body.source)
-        return {
+        response = {
             "success": True,
             "id": result_id,
             "message": "Memory added successfully" if ids else "Duplicate skipped",
         }
+        if not ids and request_body.deduplicate:
+            # Surface WHICH memory blocked the write so callers can act on it
+            # instead of silently losing a correction.
+            _, top = memory.is_novel(request_body.text)
+            if top is not None:
+                response["blocked_by"] = top.get("id")
+                response["blocked_similarity"] = round(float(top.get("similarity", 0.0)), 4)
+                response["hint"] = (
+                    f"memory {top.get('id')} already covers this; "
+                    "pass on_duplicate=supersede to replace it"
+                )
+        _audit(request, "memory.created", resource_id=str(result_id or ""), source=request_body.source)
+        return response
     except Exception as e:
         logger.exception("Add memory failed")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -452,25 +452,31 @@ server.tool(
   {
     text: z.string().min(1).describe("The memory content to store"),
     source: z.string().min(1).describe("Source identifier (e.g. 'project/decisions.md', 'bug-fix/redis')"),
-    deduplicate: z.boolean().default(true).describe("Skip if a very similar memory already exists"),
+    deduplicate: z.boolean().default(true).describe("Legacy flag; ignored when on_duplicate is set"),
+    on_duplicate: z.enum(["supersede", "skip", "add"]).default("supersede").describe("supersede (default): a colliding similar memory is replaced — the old version is archived with a supersedes link, so corrections like 'weight is now 79kg' update instead of being dropped as duplicates. skip: keep the existing memory and report which id blocked the write. add: store unconditionally."),
     document_at: z.string().optional().describe("ISO 8601 date for when the content was created (e.g. session date). Enables temporal search."),
   },
-  async ({ text, source, deduplicate = true, document_at }) => {
-    const body = { text, source, deduplicate };
+  async ({ text, source, deduplicate = true, on_duplicate = "supersede", document_at }) => {
+    const body = { text, source, on_duplicate };
     if (document_at) body.metadata = { document_at };
     const data = await memoriesRequest("/memory/add", {
       method: "POST",
       body: JSON.stringify(body),
     }, "add");
 
-    return {
-      content: [{
-        type: "text",
-        text: data.id !== null
-          ? `Memory added (id: ${data.id}) from ${source}`
-          : "Duplicate skipped — a very similar memory already exists.",
-      }],
-    };
+    let msg;
+    if (data.action === "superseded") {
+      msg = `Memory superseded: id=${data.id} replaces id=${data.superseded} (similarity ${data.similarity}); the old version is archived with a supersedes link.`;
+    } else if (data.action === "skipped") {
+      msg = `Skipped (${data.reason}): memory id=${data.blocked_by} already covers this (similarity ${data.similarity}). ${data.hint || ""}`.trim();
+    } else if (data.action === "added" || data.id !== null) {
+      msg = `Memory added (id: ${data.id}) from ${source}`;
+    } else {
+      msg = data.blocked_by !== undefined
+        ? `Duplicate skipped — memory id=${data.blocked_by} already covers this. ${data.hint || ""}`.trim()
+        : "Duplicate skipped — a very similar memory already exists.";
+    }
+    return { content: [{ type: "text", text: msg }] };
   }
 );
 

--- a/memory_engine.py
+++ b/memory_engine.py
@@ -842,29 +842,112 @@ class MemoryEngine:
             "missing_ids": missing,
         }
 
-    def supersede(self, old_id: int, new_text: str, source: str = "") -> dict:
-        """Replace a memory with an updated version, preserving audit trail."""
+    def supersede(self, old_id: int, new_text: str, source: str = "", metadata: Optional[Dict] = None) -> dict:
+        """Replace a memory with an updated version, preserving history.
+
+        The new memory is added FIRST; the old memory is then ARCHIVED (not
+        deleted) with a superseded_by pointer and a supersedes link from the
+        new memory — so timeline/evidence can render the change ("79kg,
+        was 78kg"), default search stops returning the old version, and a
+        crash mid-operation can never lose the original.
+        """
         if not self._id_exists(old_id):
             raise ValueError(f"Memory {old_id} not found")
 
-        previous_text = self._get_meta_by_id(old_id).get("text", "")
-
-        self.delete_memory(old_id)
+        old_meta = self._get_meta_by_id(old_id)
+        previous_text = old_meta.get("text", "")
+        use_source = source or old_meta.get("source", "")
 
         added_ids = self.add_memories(
             texts=[new_text],
-            sources=[source],
+            sources=[use_source],
+            metadata_list=[metadata] if metadata else None,
             deduplicate=False,
         )
         new_id = added_ids[0] if added_ids else None
+        if new_id is None or not self._id_exists(new_id):
+            raise RuntimeError("supersede: add_memories stored nothing; original left untouched")
 
-        if new_id is not None and self._id_exists(new_id):
-            self._get_meta_by_id(new_id)["supersedes"] = old_id
-            self._get_meta_by_id(new_id)["previous_text"] = previous_text
-            self.save()
+        new_meta = self._get_meta_by_id(new_id)
+        new_meta["supersedes"] = old_id
+        new_meta["previous_text"] = previous_text
+        self.add_link(new_id, old_id, "supersedes")
 
-        logger.info("Superseded memory %d → %d", old_id, new_id)
-        return {"old_id": old_id, "new_id": new_id, "previous_text": previous_text}
+        old_meta["archived"] = True
+        old_meta["superseded_by"] = new_id
+        self.qdrant_store.set_payload(old_id, {"archived": True})
+        self.save()
+
+        logger.info("Superseded memory %d → %d (old archived)", old_id, new_id)
+        return {"old_id": old_id, "new_id": new_id, "previous_text": previous_text, "archived_old": True}
+
+    def add_with_doctrine(
+        self,
+        text: str,
+        source: str,
+        metadata: Optional[Dict] = None,
+        on_duplicate: str = "supersede",
+        dedup_threshold: float = 0.90,
+        identical_threshold: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Single-memory write with update-on-collision semantics.
+
+        Every write becomes an explicit decision instead of a silent skip:
+        - no collision (top similarity < dedup_threshold) -> ADD
+        - collision, similarity >= identical_threshold     -> SKIP (true
+          duplicate; the blocking id is surfaced so callers can supersede
+          deliberately)
+        - collision below identical_threshold              -> SUPERSEDE the
+          blocker (the incoming fact is newer by definition: "weight is
+          79kg" replaces "weight is 78kg" instead of being eaten by dedup)
+        - blocker is pinned                                -> SKIP (operator
+          protection wins; surfaced in the result)
+        on_duplicate: "supersede" (default) | "skip" (legacy dedup behavior,
+        but with the blocker surfaced) | "add" (no collision check).
+        """
+        if on_duplicate not in ("add", "skip", "supersede"):
+            raise ValueError(f"on_duplicate must be add|skip|supersede, got {on_duplicate!r}")
+        if identical_threshold is None:
+            identical_threshold = float(os.getenv("DOCTRINE_IDENTICAL_THRESHOLD", "0.97"))
+
+        if on_duplicate != "add" and self.metadata:
+            novel, top = self.is_novel(text, threshold=dedup_threshold)
+            if not novel and top is not None:
+                top_id = top.get("id")
+                sim = float(top.get("similarity", 0.0))
+                blocker = self._get_meta_by_id(top_id) if self._id_exists(top_id) else {}
+                if blocker.get("pinned"):
+                    return {
+                        "action": "skipped",
+                        "reason": "pinned_blocker",
+                        "blocked_by": top_id,
+                        "similarity": round(sim, 4),
+                        "hint": f"memory {top_id} is pinned; unpin it or supersede deliberately",
+                    }
+                if on_duplicate == "skip" or sim >= identical_threshold:
+                    return {
+                        "action": "skipped",
+                        "reason": "identical" if sim >= identical_threshold else "duplicate",
+                        "blocked_by": top_id,
+                        "similarity": round(sim, 4),
+                        "hint": f"memory {top_id} already covers this; supersede it to replace the content",
+                    }
+                result = self.supersede(top_id, text, source, metadata=metadata)
+                return {
+                    "action": "superseded",
+                    "id": result["new_id"],
+                    "superseded": top_id,
+                    "similarity": round(sim, 4),
+                    "previous_text": result["previous_text"],
+                }
+
+        ids = self.add_memories(
+            texts=[text],
+            sources=[source],
+            metadata_list=[metadata] if metadata else None,
+            deduplicate=False,
+        )
+        return {"action": "added", "id": ids[0] if ids else None}
 
     def merge_memories(self, ids: List[int], merged_text: str, source: str) -> Dict[str, Any]:
         """Merge multiple memories into one, archiving originals and linking via supersedes."""

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -505,7 +505,7 @@ class TestSupersede:
     """Test memory supersede (targeted update with audit trail)."""
 
     def test_supersede_replaces_memory(self, populated_engine):
-        """Supersede deletes old memory and adds new one with link."""
+        """Supersede archives the old memory (never deletes) and adds the new one with a link."""
         old_count = populated_engine.stats_light()["total_memories"]
         old_id = 0  # first memory in populated_engine
 
@@ -517,7 +517,12 @@ class TestSupersede:
 
         assert result["old_id"] == old_id
         assert result["new_id"] is not None
-        assert populated_engine.stats_light()["total_memories"] == old_count  # same count (delete + add)
+        assert result["archived_old"] is True
+        # archive + add: the original is preserved as history, so count grows
+        assert populated_engine.stats_light()["total_memories"] == old_count + 1
+        old_meta = populated_engine._get_meta_by_id(old_id)
+        assert old_meta["archived"] is True
+        assert old_meta["superseded_by"] == result["new_id"]
 
     def test_supersede_nonexistent_id_raises(self, populated_engine):
         """Superseding a nonexistent memory raises ValueError."""

--- a/tests/test_write_doctrine.py
+++ b/tests/test_write_doctrine.py
@@ -1,0 +1,187 @@
+"""Write doctrine: every write is an explicit ADD / SUPERSEDE / SKIP decision.
+
+Pins the fix for the staleness root cause: a corrected fact ("weight is now
+79kg") used to be silently eaten by dedup-skip while the stale fact kept
+ranking. Under the doctrine the correction supersedes the original, which is
+archived (never deleted) with a supersedes link.
+"""
+
+import numpy as np
+import pytest
+
+import memory_engine as memory_engine_module
+from memory_engine import MemoryEngine
+
+DIM = 8
+
+_BASE = np.zeros(DIM, dtype=np.float32); _BASE[0] = 1.0
+_ORTH = np.zeros(DIM, dtype=np.float32); _ORTH[1] = 1.0
+_OTHER = np.zeros(DIM, dtype=np.float32); _OTHER[2] = 1.0
+
+
+def _blend(a, b, amount):
+    v = a + amount * b
+    return (v / np.linalg.norm(v)).astype(np.float32)
+
+
+T78 = "User weight is 78kg"
+T79 = "User weight is 79kg"          # cos ~0.944 vs T78 -> supersede band
+T78_NEAR = "User weight is 78 kg"    # cos ~0.995 vs T78 -> identical band
+UNRELATED = "Deploys use a blue-green strategy"
+
+_VECTORS = {
+    T78: _BASE,                          # vs T79: cos ~0.912 (supersede band)
+    T79: _blend(_BASE, _ORTH, 0.45),
+    T78_NEAR: _blend(_BASE, _ORTH, 0.10),  # vs T78: cos ~0.995 (identical); vs T79: ~0.948 (supersede)
+    UNRELATED: _OTHER,
+}
+
+
+class MappedEmbedder:
+    def get_sentence_embedding_dimension(self):
+        return DIM
+
+    def encode(self, sentences, normalize_embeddings=True, show_progress_bar=False, **kwargs):
+        if isinstance(sentences, str):
+            sentences = [sentences]
+        out = np.zeros((len(sentences), DIM), dtype=np.float32)
+        for i, text in enumerate(sentences):
+            if text in _VECTORS:
+                out[i] = _VECTORS[text]
+            else:
+                seed = abs(hash(text)) % (2**32)
+                rng = np.random.default_rng(seed)
+                vec = rng.standard_normal(DIM).astype(np.float32)
+                out[i] = vec / max(np.linalg.norm(vec), 1e-9)
+        return out
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def engine(tmp_path, monkeypatch):
+    for var in (
+        "EMBED_PROVIDER", "EMBED_MODEL", "EMBED_BASE_URL", "EMBED_API_KEY",
+        "EMBED_DIMENSION", "EMBED_COLLECTION", "EMBED_QUERY_PREFIX",
+        "EMBED_DOC_PREFIX", "EMBED_ALLOW_SPACE_REBIND", "QDRANT_COLLECTION",
+        "MODEL_NAME", "OPENAI_API_KEY", "DOCTRINE_IDENTICAL_THRESHOLD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        memory_engine_module.MemoryEngine, "_make_embedder", lambda self: MappedEmbedder()
+    )
+    return MemoryEngine(data_dir=str(tmp_path / "data"))
+
+
+def _texts(results):
+    return [r["text"] for r in results]
+
+
+class TestSupersedeArchivesNotDeletes:
+    def test_supersede_archives_old_and_links_new(self, engine):
+        old_id = engine.add_memories([T78], ["learning/health"])[0]
+
+        out = engine.supersede(old_id, T79)
+
+        new_id = out["new_id"]
+        assert out["archived_old"] is True
+        old_meta = engine._get_meta_by_id(old_id)
+        assert old_meta["archived"] is True
+        assert old_meta["superseded_by"] == new_id
+        new_meta = engine._get_meta_by_id(new_id)
+        assert new_meta["supersedes"] == old_id
+        assert new_meta["previous_text"] == T78
+        # source inherited from the original when not given
+        assert new_meta["source"] == "learning/health"
+
+        default = engine.search(T79, k=5)
+        assert T78 not in _texts(default), "archived original must not surface in default search"
+        assert T79 in _texts(default)
+
+        with_archived = engine.search(T78, k=5, include_archived=True)
+        assert T78 in _texts(with_archived), "history must remain reachable via include_archived"
+
+    def test_supersede_keeps_original_when_add_fails(self, engine, monkeypatch):
+        old_id = engine.add_memories([T78], ["learning/health"])[0]
+        monkeypatch.setattr(engine, "add_memories", lambda *a, **k: [])
+
+        with pytest.raises(RuntimeError):
+            engine.supersede(old_id, T79)
+
+        old_meta = engine._get_meta_by_id(old_id)
+        assert not old_meta.get("archived"), "original must be untouched when the add fails"
+
+
+class TestAddWithDoctrine:
+    def test_correction_supersedes_original(self, engine):
+        first = engine.add_with_doctrine(T78, "learning/health")
+        assert first["action"] == "added"
+
+        second = engine.add_with_doctrine(T79, "learning/health")
+
+        assert second["action"] == "superseded"
+        assert second["superseded"] == first["id"]
+        assert 0.90 <= second["similarity"] < 0.97
+        top = engine.search("User weight is 79kg", k=3)
+        assert _texts(top)[0] == T79
+        assert T78 not in _texts(top)
+        assert engine._get_meta_by_id(first["id"])["archived"] is True
+
+    def test_identical_text_is_skipped_with_blocker(self, engine):
+        first = engine.add_with_doctrine(T78, "learning/health")
+
+        out = engine.add_with_doctrine(T78_NEAR, "learning/health")
+
+        assert out["action"] == "skipped"
+        assert out["reason"] == "identical"
+        assert out["blocked_by"] == first["id"]
+        assert "supersede" in out["hint"]
+
+    def test_skip_mode_keeps_legacy_behavior_but_surfaces_blocker(self, engine):
+        first = engine.add_with_doctrine(T78, "learning/health")
+
+        out = engine.add_with_doctrine(T79, "learning/health", on_duplicate="skip")
+
+        assert out["action"] == "skipped"
+        assert out["reason"] == "duplicate"
+        assert out["blocked_by"] == first["id"]
+        assert not engine._get_meta_by_id(first["id"]).get("archived")
+
+    def test_pinned_blocker_is_never_superseded(self, engine):
+        first = engine.add_with_doctrine(T78, "learning/health")
+        engine.update_memory(first["id"], pinned=True)
+
+        out = engine.add_with_doctrine(T79, "learning/health")
+
+        assert out["action"] == "skipped"
+        assert out["reason"] == "pinned_blocker"
+        assert not engine._get_meta_by_id(first["id"]).get("archived")
+
+    def test_add_mode_bypasses_collision_check(self, engine):
+        engine.add_with_doctrine(T78, "learning/health")
+        out = engine.add_with_doctrine(T79, "learning/health", on_duplicate="add")
+        assert out["action"] == "added"
+        both = engine.search(T79, k=5)
+        assert T78 in _texts(both) and T79 in _texts(both)
+
+    def test_unrelated_text_adds_normally(self, engine):
+        engine.add_with_doctrine(T78, "learning/health")
+        out = engine.add_with_doctrine(UNRELATED, "learning/deploys")
+        assert out["action"] == "added"
+
+    def test_invalid_mode_rejected(self, engine):
+        with pytest.raises(ValueError):
+            engine.add_with_doctrine(T78, "learning/health", on_duplicate="merge")
+
+    def test_superseded_old_does_not_block_future_writes(self, engine):
+        """The archived original must not act as a dedup blocker later."""
+        engine.add_with_doctrine(T78, "learning/health")
+        second = engine.add_with_doctrine(T79, "learning/health")
+        assert second["action"] == "superseded"
+
+        third = engine.add_with_doctrine(T78_NEAR, "learning/health")
+        # T78_NEAR collides with archived T78 (0.995) but archived memories are
+        # excluded from search; against live T79 it sits in the supersede band.
+        assert third["action"] == "superseded"
+        assert third["superseded"] == second["id"]


### PR DESCRIPTION
First PR of the write-doctrine epic (per docs/decisions/2026-06-10-release-process.md).

## Problem
A corrected fact ("weight is now 79kg") was silently eaten: MCP `memory_add` defaults `deduplicate=true` → `is_novel` at 0.90 → skip, no trace. And `supersede()` — the only update primitive — hard-deleted the old version (no history) with a delete-before-add crash window.

## Changes
- `supersede()`: add-first, then **archive** the original with `superseded_by` + a `supersedes` link. History stays reachable via `include_archived`/timeline; default search drops the stale version; crash mid-operation can never lose data.
- `add_with_doctrine()`: every write is an explicit decision — supersede the blocker in the 0.90–0.97 band, skip with `blocked_by` surfaced at ≥0.97 (true duplicate), never supersede pinned blockers, `on_duplicate=add` bypass.
- `POST /memory/add`: additive `on_duplicate` param; legacy dedup skips now report `blocked_by` + hint.
- MCP `memory_add`: defaults to `on_duplicate=supersede`, renders the action taken.

## Tests
10 new doctrine tests with a controlled-similarity embedder (supersede band vs identical band vs pinned blocker vs chain-after-supersede); 1 updated supersede test (archive semantics). Full suite: **1669 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)