### PR TITLE
Conflict-queue drain: newest wins, loser archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Conflict-queue drain** — `resolve_conflicts` resolves `conflicts_with` markers under newest-wins: the newer of the pair stays live, the older is **archived** with a `supersedes` link (recoverable, never deleted). Pinned losers and undated pairs stay queued marked `needs_review`; orphaned markers (other side gone or already archived) are cleared. Exposed as `POST /memory/conflicts/resolve` (dry-run by default; unscoped key required) and as a daily scheduled maintenance job (3:30 UTC, `MAINTENANCE_CONFLICT_DRAIN`, capped by `MAINTENANCE_CONFLICT_MAX`, default 200/run). `GET /memory/conflicts` now annotates entries held for review.
+
 ## [5.6.0] - 2026-06-10
 
 ### Fixed

--- a/app.py
+++ b/app.py
@@ -140,6 +140,8 @@ EMBEDDER_AUTO_RELOAD_MAX_QUEUE_DEPTH = _env_int(
     minimum=0,
 )
 MAINTENANCE_ENABLED = _env_bool("MAINTENANCE_ENABLED", False)
+_MAINTENANCE_CONFLICT_DRAIN = _env_bool("MAINTENANCE_CONFLICT_DRAIN", True)
+_MAINTENANCE_CONFLICT_MAX = int(os.getenv("MAINTENANCE_CONFLICT_MAX", "200"))
 METRICS_LATENCY_SAMPLES = _env_int("METRICS_LATENCY_SAMPLES", 200, minimum=20)
 METRICS_TREND_SAMPLES = _env_int("METRICS_TREND_SAMPLES", 120, minimum=5)
 EXTRACT_FALLBACK_ADD_ENABLED = _env_bool("EXTRACT_FALLBACK_ADD", False)
@@ -1024,10 +1026,22 @@ def _run_scheduled_pruning():
     return deleted
 
 
+def _run_scheduled_conflict_drain():
+    """Drain the conflict queue synchronously (called from threadpool)."""
+    logger.info("Maintenance started: conflict drain")
+    result = memory.resolve_conflicts(dry_run=False, max_resolutions=_MAINTENANCE_CONFLICT_MAX)
+    logger.info(
+        "Maintenance complete: conflict drain — %d resolved, %d need review, %d orphaned markers cleared",
+        result["resolved_count"], result["needs_review_count"], result["orphaned_count"],
+    )
+    return result["resolved_count"]
+
+
 async def _maintenance_scheduler():
-    """Run consolidation daily and pruning weekly."""
+    """Run consolidation + conflict drain daily and pruning weekly."""
     _last_consolidation_date = None
     _last_prune_date = None
+    _last_conflict_date = None
     while True:
         now = datetime.now(timezone.utc)
         today = now.date()
@@ -1040,6 +1054,15 @@ async def _maintenance_scheduler():
                 logger.info("Scheduled consolidation complete: %d clusters merged", n)
             except Exception:
                 logger.exception("Scheduled consolidation failed")
+        # Conflict drain: daily at 3:30 AM UTC (after consolidation)
+        if _MAINTENANCE_CONFLICT_DRAIN and now.hour == 3 and 30 <= now.minute < 35 and _last_conflict_date != today:
+            _last_conflict_date = today
+            try:
+                logger.info("Running scheduled conflict drain")
+                n = await run_in_threadpool(_run_scheduled_conflict_drain)
+                logger.info("Scheduled conflict drain complete: %d resolved", n)
+            except Exception:
+                logger.exception("Scheduled conflict drain failed")
         # Pruning: Sunday at 4 AM UTC (once per week)
         if now.weekday() == 6 and now.hour == 4 and now.minute < 5 and _last_prune_date != today:
             _last_prune_date = today
@@ -2298,6 +2321,8 @@ async def list_conflicts(request: Request):
         if auth.prefixes is not None and not auth.can_read(m.get("source", "")):
             continue
         entry = {**m}
+        if m.get("conflict_review"):
+            entry["needs_review"] = m["conflict_review"]
         try:
             conflicting = memory.get_memory(cw)
             if auth.can_read(conflicting.get("source", "")):
@@ -2308,6 +2333,30 @@ async def list_conflicts(request: Request):
             entry["conflicting_memory"] = None
         conflicts.append(entry)
     return {"conflicts": conflicts, "count": len(conflicts)}
+
+
+class ResolveConflictsRequest(BaseModel):
+    dry_run: bool = True
+    max: int = Field(0, ge=0, le=10000, description="Max resolutions this run (0 = unlimited)")
+
+
+@app.post("/memory/conflicts/resolve")
+async def resolve_conflicts(request_body: ResolveConflictsRequest, request: Request):
+    """Drain the conflict queue (newest wins; loser archived with a supersedes link)."""
+    auth = _get_auth(request)
+    if auth.role == "read-only":
+        raise HTTPException(status_code=403, detail="Read-only keys cannot resolve conflicts")
+    if auth.prefixes is not None:
+        raise HTTPException(status_code=403, detail="Conflict resolution spans sources; an unscoped key is required")
+    logger.info("Resolve conflicts: dry_run=%s max=%d", request_body.dry_run, request_body.max)
+    try:
+        result = memory.resolve_conflicts(dry_run=request_body.dry_run, max_resolutions=request_body.max)
+        if not request_body.dry_run:
+            _audit(request, "memory.conflicts_resolved", resource_id=str(result["resolved_count"]))
+        return {"success": True, **result}
+    except Exception:
+        logger.exception("Conflict resolution failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.delete("/memory/{memory_id}")

--- a/memory_engine.py
+++ b/memory_engine.py
@@ -866,6 +866,110 @@ class MemoryEngine:
         logger.info("Superseded memory %d → %d", old_id, new_id)
         return {"old_id": old_id, "new_id": new_id, "previous_text": previous_text}
 
+    def resolve_conflicts(
+        self,
+        dry_run: bool = True,
+        policy: str = "newest_wins",
+        max_resolutions: int = 0,
+    ) -> Dict[str, Any]:
+        """Drain the conflict queue.
+
+        Extraction flags contradictions by storing the new fact with a
+        ``conflicts_with`` marker — and historically nothing ever resolved
+        them. Under ``newest_wins`` the newer of the pair stays live and the
+        older is ARCHIVED with a supersedes link (never deleted, recoverable
+        via include_archived). Pinned losers and pairs without usable dates
+        are left in the queue marked ``conflict_review``; markers whose other
+        side no longer exists (or is already archived) are cleared as
+        orphaned. dry_run reports what would happen without mutating.
+        """
+        if policy != "newest_wins":
+            raise ValueError(f"unknown conflict policy: {policy!r}")
+
+        def _when(meta: Dict) -> Optional[datetime]:
+            for key in ("document_at", "created_at", "timestamp"):
+                val = meta.get(key)
+                if not val:
+                    continue
+                try:
+                    parsed = datetime.fromisoformat(str(val).replace("Z", "+00:00"))
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=timezone.utc)
+                    return parsed
+                except (ValueError, TypeError):
+                    continue
+            return None
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        resolved: List[Dict[str, Any]] = []
+        needs_review: List[Dict[str, Any]] = []
+        orphaned: List[Dict[str, Any]] = []
+        mutated = False
+
+        for m in list(self.metadata):
+            if not m or m.get("archived") or m.get("deferred"):
+                continue
+            cw = m.get("conflicts_with")
+            if cw is None:
+                continue
+            if max_resolutions and len(resolved) + len(orphaned) >= max_resolutions:
+                break
+            mid = m["id"]
+
+            other = self._get_meta_by_id(cw) if self._id_exists(cw) else None
+            if other is None or other.get("archived"):
+                reason = "missing" if other is None else "already_archived"
+                orphaned.append({"id": mid, "conflicts_with": cw, "reason": reason})
+                if not dry_run:
+                    m["conflict_resolution"] = {"policy": policy, "outcome": f"orphaned_{reason}", "other": cw, "at": now_iso}
+                    m.pop("conflicts_with", None)
+                    mutated = True
+                continue
+
+            t_m, t_o = _when(m), _when(other)
+            if t_m is None or t_o is None:
+                needs_review.append({"id": mid, "conflicts_with": cw, "reason": "undated"})
+                if not dry_run and m.get("conflict_review") != "undated":
+                    m["conflict_review"] = "undated"
+                    mutated = True
+                continue
+
+            # Tie goes to the flagging memory: it was stored later by construction.
+            winner, loser = (m, other) if t_m >= t_o else (other, m)
+            if loser.get("pinned"):
+                needs_review.append({"id": mid, "conflicts_with": cw, "reason": "pinned_loser"})
+                if not dry_run and m.get("conflict_review") != "pinned_loser":
+                    m["conflict_review"] = "pinned_loser"
+                    mutated = True
+                continue
+
+            if not dry_run:
+                loser["archived"] = True
+                loser["superseded_by"] = winner["id"]
+                self.qdrant_store.set_payload(loser["id"], {"archived": True})
+                self.add_link(winner["id"], loser["id"], "supersedes")
+                winner["conflict_resolution"] = {
+                    "policy": policy, "outcome": "won", "archived": loser["id"], "at": now_iso,
+                }
+                m.pop("conflicts_with", None)
+                m.pop("conflict_review", None)
+                mutated = True
+            resolved.append({"kept": winner["id"], "archived": loser["id"], "flagger": mid})
+
+        if not dry_run and mutated:
+            self.save()
+
+        return {
+            "dry_run": dry_run,
+            "policy": policy,
+            "resolved": resolved,
+            "needs_review": needs_review,
+            "orphaned": orphaned,
+            "resolved_count": len(resolved),
+            "needs_review_count": len(needs_review),
+            "orphaned_count": len(orphaned),
+        }
+
     def merge_memories(self, ids: List[int], merged_text: str, source: str) -> Dict[str, Any]:
         """Merge multiple memories into one, archiving originals and linking via supersedes."""
         if len(ids) < 2:

--- a/tests/test_conflict_drain.py
+++ b/tests/test_conflict_drain.py
@@ -1,0 +1,166 @@
+"""Conflict-queue drain: newest wins, loser archived with a supersedes link.
+
+Extraction flags contradictions with ``conflicts_with`` markers and — until
+now — nothing ever resolved them (223 unresolved in production at audit time).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pytest
+
+import memory_engine as memory_engine_module
+from memory_engine import MemoryEngine
+
+DIM = 8
+
+
+class HashEmbedder:
+    def get_sentence_embedding_dimension(self):
+        return DIM
+
+    def encode(self, sentences, normalize_embeddings=True, show_progress_bar=False, **kwargs):
+        if isinstance(sentences, str):
+            sentences = [sentences]
+        out = np.zeros((len(sentences), DIM), dtype=np.float32)
+        for i, text in enumerate(sentences):
+            rng = np.random.default_rng(abs(hash(text)) % (2**32))
+            vec = rng.standard_normal(DIM).astype(np.float32)
+            out[i] = vec / max(np.linalg.norm(vec), 1e-9)
+        return out
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def engine(tmp_path, monkeypatch):
+    for var in (
+        "EMBED_PROVIDER", "EMBED_MODEL", "EMBED_DIMENSION", "EMBED_COLLECTION",
+        "QDRANT_COLLECTION", "MODEL_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        memory_engine_module.MemoryEngine, "_make_embedder", lambda self: HashEmbedder()
+    )
+    return MemoryEngine(data_dir=str(tmp_path / "data"))
+
+
+def _iso(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def _add(engine, text, days_ago, **extra):
+    mid = engine.add_memories([text], ["learning/x"])[0]
+    meta = engine._get_meta_by_id(mid)
+    meta["created_at"] = _iso(days_ago)
+    meta.update(extra)
+    return mid
+
+
+def _conflict_pair(engine, *, old_days=30, new_days=1, old_extra=None, new_extra=None):
+    old_id = _add(engine, "relay identity is dk-fplguru", old_days, **(old_extra or {}))
+    new_id = _add(engine, "relay identity is dk-local-llm", new_days, **(new_extra or {}))
+    engine._get_meta_by_id(new_id)["conflicts_with"] = old_id
+    return old_id, new_id
+
+
+def test_dry_run_reports_without_mutating(engine):
+    old_id, new_id = _conflict_pair(engine)
+
+    out = engine.resolve_conflicts(dry_run=True)
+
+    assert out["resolved_count"] == 1
+    assert out["resolved"][0] == {"kept": new_id, "archived": old_id, "flagger": new_id}
+    assert not engine._get_meta_by_id(old_id).get("archived")
+    assert engine._get_meta_by_id(new_id).get("conflicts_with") == old_id
+
+
+def test_newest_wins_archives_older_side(engine):
+    old_id, new_id = _conflict_pair(engine)
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["resolved_count"] == 1
+    old_meta = engine._get_meta_by_id(old_id)
+    new_meta = engine._get_meta_by_id(new_id)
+    assert old_meta["archived"] is True
+    assert old_meta["superseded_by"] == new_id
+    assert "conflicts_with" not in new_meta
+    assert new_meta["conflict_resolution"]["outcome"] == "won"
+    # second run is a no-op: the queue actually drains
+    again = engine.resolve_conflicts(dry_run=False)
+    assert again["resolved_count"] == 0
+
+
+def test_older_flagger_loses_to_newer_existing_memory(engine):
+    """If the flagging memory is somehow OLDER, the existing newer memory wins."""
+    old_id, new_id = _conflict_pair(engine, old_days=1, new_days=30)
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["resolved"][0]["kept"] == old_id
+    flagger = engine._get_meta_by_id(new_id)
+    assert flagger["archived"] is True
+    assert flagger["superseded_by"] == old_id
+
+
+def test_pinned_loser_goes_to_review_not_archive(engine):
+    old_id, new_id = _conflict_pair(engine, old_extra={"pinned": True})
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["resolved_count"] == 0
+    assert out["needs_review"][0]["reason"] == "pinned_loser"
+    assert not engine._get_meta_by_id(old_id).get("archived")
+    assert engine._get_meta_by_id(new_id)["conflict_review"] == "pinned_loser"
+    assert engine._get_meta_by_id(new_id)["conflicts_with"] == old_id
+
+
+def test_undated_pair_goes_to_review(engine):
+    old_id, new_id = _conflict_pair(engine)
+    engine._get_meta_by_id(old_id).pop("created_at", None)
+    engine._get_meta_by_id(old_id).pop("timestamp", None)
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["needs_review"][0]["reason"] == "undated"
+    assert not engine._get_meta_by_id(old_id).get("archived")
+
+
+def test_orphaned_marker_is_cleared(engine):
+    _, new_id = _conflict_pair(engine)
+    engine._get_meta_by_id(new_id)["conflicts_with"] = 99999  # other side gone
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["orphaned_count"] == 1
+    meta = engine._get_meta_by_id(new_id)
+    assert "conflicts_with" not in meta
+    assert meta["conflict_resolution"]["outcome"] == "orphaned_missing"
+
+
+def test_already_archived_other_side_clears_marker(engine):
+    old_id, new_id = _conflict_pair(engine)
+    engine._get_meta_by_id(old_id)["archived"] = True
+
+    out = engine.resolve_conflicts(dry_run=False)
+
+    assert out["orphaned_count"] == 1
+    assert "conflicts_with" not in engine._get_meta_by_id(new_id)
+
+
+def test_max_resolutions_caps_a_run(engine):
+    for _ in range(3):
+        _conflict_pair(engine)
+
+    out = engine.resolve_conflicts(dry_run=False, max_resolutions=2)
+
+    assert out["resolved_count"] == 2
+    remaining = engine.resolve_conflicts(dry_run=True)
+    assert remaining["resolved_count"] == 1
+
+
+def test_unknown_policy_rejected(engine):
+    with pytest.raises(ValueError):
+        engine.resolve_conflicts(policy="oldest_wins")


### PR DESCRIPTION
Second PR of the write-doctrine epic.

## Problem
Extraction detects contradictions and stores `conflicts_with` markers — but nothing ever resolved them: 223 unresolved conflicts in production at audit time, growing monotonically.

## Changes
- `engine.resolve_conflicts(dry_run, max_resolutions)`: newest-wins resolution — newer side stays live, older side **archived** with `superseded_by` + a `supersedes` link (same history semantics as the doctrine supersede; nothing destroyed). Pinned losers and undated pairs are held with `needs_review` markers; orphaned markers (other side deleted or already archived) are cleared.
- `POST /memory/conflicts/resolve` — dry-run by default; requires an unscoped key (conflicts span source prefixes).
- Third scheduled maintenance job: daily conflict drain at 3:30 UTC (after consolidation), gated by `MAINTENANCE_CONFLICT_DRAIN` (default on when maintenance is enabled), capped at `MAINTENANCE_CONFLICT_MAX` (200) per run.
- `GET /memory/conflicts` annotates entries held for review.

## Tests
9 new tests: dry-run non-mutation, newest-wins both directions, queue actually drains (second run is a no-op), pinned-loser hold, undated hold, orphaned/already-archived clearing, per-run cap. Full suite: **1668 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)