### PR TITLE
fix(watcher): failed submits must not advance the session watermark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Transcript watcher no longer drops backlog on failed submits** — `run_once` advanced the per-session watermark even when the extraction submit failed, so any rejected submission (seen live: the cold-start sweep flooding the extract queue with 429s) silently skipped that session's messages forever. The watermark now only advances after a successful submit (or when there is nothing to send), so failed sessions are retried on the next poll pass.
+
 ## [5.7.1] - 2026-06-12
 
 ### Fixed

--- a/scripts/transcript_watcher.py
+++ b/scripts/transcript_watcher.py
@@ -225,9 +225,10 @@ def run_once(cfg, state, now=None) -> int:
         if text:
             project = resolve_project(messages[-1].get("cwd", ""))
             source = f"{cfg['source_prefix']}/{project}"
-            if _submit_extraction(cfg["base"], cfg["key"], text, source):
-                captured += 1
-                print(f"[watcher] captured {len(text)} chars -> {source}", file=sys.stderr)
+            if not _submit_extraction(cfg["base"], cfg["key"], text, source):
+                continue  # leave the watermark in place — retried next pass
+            captured += 1
+            print(f"[watcher] captured {len(text)} chars -> {source}", file=sys.stderr)
         state[key] = {"mtime": st.st_mtime, "cursor": new_cursor}
     return captured
 

--- a/tests/test_transcript_watcher.py
+++ b/tests/test_transcript_watcher.py
@@ -160,6 +160,26 @@ class TestRunOnce:
         self._write_transcript(cfg, "s.jsonl", [("user", "u1", "x" * 100)], mtime=1950.0)
         assert w.run_once(cfg, {}, now=2000.0) == 0
 
+    def test_failed_submit_does_not_advance_cursor(self, cfg, monkeypatch):
+        """A 429/error on submit must leave the watermark in place so the next
+        pass retries; advancing it silently drops the backlog (seen live when
+        the cold-start sweep flooded the extract queue)."""
+        import scripts.transcript_watcher as w
+        monkeypatch.setattr(w, "_backend_healthy", lambda *a: True)
+        monkeypatch.setattr(w, "_submit_extraction", lambda *a: False)
+        self._write_transcript(cfg, "s.jsonl", [
+            ("user", "u1", "Decision: we will use Qdrant for the vector store because it scales."),
+            ("assistant", "a1", "Got it, recording that decision."),
+        ], mtime=1000.0)
+
+        state = {}
+        assert w.run_once(cfg, state, now=2000.0) == 0
+
+        submitted = []
+        monkeypatch.setattr(w, "_submit_extraction", lambda base, key, text, source: submitted.append(text) or True)
+        assert w.run_once(cfg, state, now=2100.0) == 1
+        assert "Qdrant" in submitted[0]
+
     def test_watermark_prevents_recapture(self, cfg, monkeypatch):
         import scripts.transcript_watcher as w
         monkeypatch.setattr(w, "_backend_healthy", lambda *a: True)


### PR DESCRIPTION
## What happened

Installing the v5.7.0 transcript watcher for the first time today (it had shipped but was never installed), its cold-start sweep flooded the extract queue and got 429 `extract_queue_full` on several sessions — and the watcher **advanced those sessions' watermarks anyway**, permanently skipping the unsubmitted backlog. The "idempotent across idle bursts and restarts" guarantee only held for successful submits.

## Fix

`run_once` now leaves the session's state entry untouched when `_submit_extraction` fails, so the next poll pass (60s) retries it. The skip-unchanged check (`entry.mtime == st.mtime and entry.cursor`) only matches entries written by a successful pass, so retries can't be starved. The natural 60s retry cadence also drains a flooded queue without extra throttling.

## Test

TDD red→green: new `test_failed_submit_does_not_advance_cursor` (fail one pass, succeed the next, assert the same content is captured) — failed before the fix exactly as observed live. Watcher suite 19 passed; full suite **1744 passed**.

## Deployment note

The watcher is currently **uninstalled** (stopped it to halt the loss). After merge: wipe `~/.config/memories/watcher-state.json` (the live run baked falsely-advanced cursors into it; backend dedup absorbs the re-sweep) and reinstall via `install-watcher.sh install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)