### PR TITLE
chore(plugin): add Claude Code plugin manifest; refresh release version-location list

### DIFF
--- a/docs/decisions/2026-06-10-release-process.md
+++ b/docs/decisions/2026-06-10-release-process.md
@@ -19,11 +19,20 @@ Stop cutting a release per work item. The flow is now:
 
 ## Mechanics of a promotion
 
-- Bump every version string (the seven: `pyproject.toml`,
-  `plugin/package.json`, `mcp-server/package.json` + lockfile,
-  `plugin/assets/BACKEND_VERSION`, `app.py` (FastAPI + /health),
-  `tests/test_api_contract_compat.py`, `plugins/memories/.codex-plugin/plugin.json`)
-  and grep the old version project-wide before committing.
+- Bump every version string (the eight, current as of v5.9.0: `pyproject.toml`,
+  `mcp-server/package.json` + lockfile, `uv.lock`,
+  `mcp-server/assets/backend/BACKEND_VERSION`, `app.py` (FastAPI + /health),
+  `tests/test_api_contract_compat.py`, `plugins/memories/.codex-plugin/plugin.json`,
+  `mcp-server/assets/claude-code/.claude-plugin/plugin.json` (Claude Code plugin
+  manifest — `dk-marketplace/sync.sh` reads its version into `marketplace.json`,
+  so a stale value here silently mis-advertises the plugin), plus `README.md`'s
+  "Key capabilities (vX.Y.Z)" line.
+  `plugin/package.json` and `plugin/assets/BACKEND_VERSION` are GONE as of the
+  v5.8.0 asset consolidation — `plugin/` is now a symlink to
+  `mcp-server/assets/claude-code`.
+  Grep the old version project-wide before committing, and include `*.mjs`/`*.js`
+  in that grep: a hardcoded `version:` in `mcp-server/lib-tools.mjs` was missed
+  for two releases because earlier sweeps only checked json/toml/py/md.
 - Retitle CHANGELOG `[Unreleased]` to the version + date.
 - Full suite green → `chore: release vX.Y.Z` on develop → `--no-ff` merge to
   `main` → tag → push → GitHub release → deploy (compose build + up) → sync

--- a/mcp-server/assets/claude-code/.claude-plugin/plugin.json
+++ b/mcp-server/assets/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "memories",
+  "description": "Self-hosted semantic memory with graph-aware search (PPR multi-hop traversal), temporal reasoning (version preservation, date-range filters), multi-backend routing, 6-signal hybrid search, auto-feature metrics, operator workbench, lifecycle policies, and full audit trail",
+  "version": "5.9.0",
+  "author": { "name": "Divyekant Gupta" },
+  "homepage": "https://github.com/divyekant/memories",
+  "repository": "https://github.com/divyekant/memories",
+  "license": "MIT",
+  "keywords": ["memory", "memories", "mcp", "semantic-search", "agent-memory", "recall", "extraction"]
+}


### PR DESCRIPTION
Follow-on from the marketplace fix ([dk-marketplace@11dec56](https://github.com/divyekant/dk-marketplace/commit/11dec56)).

## Why

Two gaps found while making the plugin installable outside dk's Mac:

1. **No plugin manifest.** The memories plugin was the only one of dk-marketplace's 17 without `.claude-plugin/plugin.json`, so it couldn't describe itself — its identity lived entirely in the marketplace entry. With a manifest it's portable to any marketplace and to `claude --plugin-dir`.
2. **Stale release checklist.** The version-location list still named `plugin/package.json` and `plugin/assets/BACKEND_VERSION`, both deleted in the v5.8.0 consolidation, and omitted `uv.lock`, README's capabilities line, and this new manifest. It also now warns to include `*.mjs`/`*.js` in the version grep — a hardcoded version in `lib-tools.mjs` survived two releases because earlier sweeps only checked json/toml/py/md.

## Notes

- Manifest version tracks the release (5.9.0); `sync.sh` in dk-marketplace reads this field, so a stale value would silently mis-advertise the plugin — hence adding it to the checklist in the same change.
- Ships in the npm tarball automatically (`assets/` is already in `files`); verified via `npm pack --dry-run`.
- Inert for the CLI installer, which copies specific hook/skill files rather than the directory wholesale. 190/190 node tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)