### PR TITLE
fix(hooks): stop post-compaction rehydration aborting on hybrid search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Post-compaction rehydration aborted whenever it merged a second batch.** `memory-rehydrate.sh` ranked merged results with `sort_by(-.similarity // -.rrf_score)`, but jq negates `.similarity` before considering the alternative, so a hybrid-search result — which carries `rrf_score` and no `similarity` — raised `null (null) cannot be negated` and the hook exited non-zero with no context injected. It only triggered from the second source prefix onward, which is why it looked intermittent; the existing test supplied a single batch with `similarity` present and never exercised the merge.
+
 ### Added
 - **`init --mcp-name <name>`** — writes the read-only permission allowlist for a differently-named MCP server in addition to `memories`. Claude Code's `permissions.allow` only accepts a tool glob after a literal, glob-free server segment (`mcp__*__memory_search` is skipped with a warning and auto-approves nothing), so an installer cannot pre-approve tools on a server whose name it does not know. The allowlist stays enumerated per tool rather than collapsing to `mcp__<server>__*`, which would also pre-approve `memory_delete`.
 

--- a/mcp-server/assets/claude-code/hooks/memory-rehydrate.sh
+++ b/mcp-server/assets/claude-code/hooks/memory-rehydrate.sh
@@ -53,7 +53,10 @@ for tpl in $(echo "$PREFIXES" | tr ',' ' '); do
 
   BATCH_RESULTS=$(echo "$BATCH" | jq -r '.results // []')
   if [ -n "$RESULTS" ]; then
-    RESULTS=$(echo "$RESULTS $BATCH_RESULTS" | jq -s 'add | unique_by(.id) | sort_by(-.similarity // -.rrf_score) | .[0:6]')
+    # Negate the resolved score, not each candidate: `-.similarity // -.rrf_score`
+    # negates before the alternative is considered, so a hybrid-search result
+    # (rrf_score, no similarity) aborts the merge instead of falling through.
+    RESULTS=$(echo "$RESULTS $BATCH_RESULTS" | jq -s 'add | unique_by(.id) | sort_by(-(.similarity // .rrf_score // 0)) | .[0:6]')
   else
     RESULTS="$BATCH_RESULTS"
   fi

--- a/tests/test_claude_memory_hooks.py
+++ b/tests/test_claude_memory_hooks.py
@@ -1240,6 +1240,48 @@ def test_memory_rehydrate_syncs_pointers_not_full_memory_text(tmp_path: Path) ->
     assert "Compaction should not rehydrate full memory text" not in updated
 
 
+def test_memory_rehydrate_merges_batches_without_similarity_field(tmp_path: Path) -> None:
+    """Hybrid search returns rrf_score, not similarity. Merging a second batch
+    sorted with `-.similarity // -.rrf_score` throws, because jq negates
+    .similarity before the alternative is considered — so a null similarity is
+    an error, not a fallback. Two prefixes are required: the merge only runs
+    once RESULTS is already non-empty."""
+    memory_file = (
+        tmp_path / "home" / ".claude" / "projects" / "Users-example-memories" / "memory" / "MEMORY.md"
+    )
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text("# Manual note\n", encoding="utf-8")
+
+    responses = [
+        {
+            "url_suffix": "/search",
+            "source_prefix": "claude-code/memories",
+            "response": {"results": [{"id": 11, "source": "claude-code/memories", "rrf_score": 0.4}], "count": 1},
+        },
+        {
+            "url_suffix": "/search",
+            "source_prefix": "learning/memories",
+            "response": {"results": [{"id": 22, "source": "learning/memories", "rrf_score": 0.9}], "count": 1},
+        },
+    ]
+
+    payload = {"cwd": "/Users/example/memories", "compact_summary": "rehydrate merge"}
+    result, _, _ = _run_hook(
+        REHYDRATE_SCRIPT,
+        tmp_path,
+        payload,
+        responses,
+        extra_env={"MEMORIES_SOURCE_PREFIXES": "claude-code/memories,learning/memories"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "cannot be negated" not in result.stderr
+    updated = memory_file.read_text(encoding="utf-8")
+    # Both batches survive the merge, ranked by the score that is present.
+    assert "candidate memory id=22" in updated
+    assert "candidate memory id=11" in updated
+
+
 def test_memory_recall_uses_codex_source_prefixes_when_installed_under_codex(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     installed_recall = _install_hook_fixture(home_dir, "memory-recall.sh")


### PR DESCRIPTION
## What

`memory-rehydrate.sh` merged multi-prefix search batches with:

```
sort_by(-.similarity // -.rrf_score)
```

jq negates `.similarity` **before** evaluating the `//` alternative, so a result carrying `rrf_score` and no `similarity` — which is what hybrid search returns — raises an error rather than falling through to the alternative.

## Evidence

Observed live in a `PostCompact` run, not hypothetically:

```
PostCompact [${CLAUDE_PLUGIN_ROOT}/hooks/memory-rehydrate.sh] failed: jq: error (at <stdin>:79): null (null) cannot be negated
```

Reduced:

```
$ echo '[{"id":1,"rrf_score":0.5}]' | jq -s 'sort_by(-.similarity // -.rrf_score)'
jq: error (at <stdin>:1): null (null) cannot be negated
```

The hook exits 5 and injects no context, so post-compaction recall silently does nothing.

## Why the suite missed it

The merge branch only runs once `RESULTS` is already non-empty — i.e. from the **second** source prefix onward, which is why it looked intermittent. The existing rehydrate test supplied a single batch with `similarity` present, so it never reached the failing line.

## Fix

Negate the resolved score rather than each candidate:

```
sort_by(-(.similarity // .rrf_score // 0))
```

The regression test drives two prefixes with `rrf_score`-only results and asserts both survive the merge, ranked by whichever score is present. It fails with `null (null) cannot be negated` against the unfixed hook.

Swept the rest of the hook assets for the same shape — no other occurrences.

Suites: 1764 pytest, 211 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)