### PR TITLE
docs(release): name the plugin-refresh step the pin bump does not cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- **Version-consistency guard.** `test_backend_version_marker_matches_health_version` asserts that `mcp-server/assets/backend/BACKEND_VERSION` matches the version `/health` reports. `memories doctor` compares those two exact values and recommends `memories update` on any difference — a command that only rewires clients and cannot update a running backend — so a checkout where they disagree produces a permanent, unactionable warning. A half-applied version bump now fails CI instead of shipping.
+- **Version-consistency guard.** `test_backend_version_sources_agree` asserts that all four backend-facing version sources match: `mcp-server/assets/backend/BACKEND_VERSION`, the version `/health` reports, `FastAPI(version=)`, and the OpenAPI `info.version` it serves. `memories doctor` compares the first two and recommends `memories update` on any difference — a command that only rewires clients and cannot update a running backend — so a checkout where they disagree produces a permanent, unactionable warning; the FastAPI metadata is public API surface that nothing else asserted. Each source is verified to fail the guard on its own, so a bump applied to any subset fails CI instead of shipping.
 
 ## [5.11.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Version-consistency guard.** `test_backend_version_marker_matches_health_version` asserts that `mcp-server/assets/backend/BACKEND_VERSION` matches the version `/health` reports. `memories doctor` compares those two exact values and recommends `memories update` on any difference — a command that only rewires clients and cannot update a running backend — so a checkout where they disagree produces a permanent, unactionable warning. A half-applied version bump now fails CI instead of shipping.
+
 ## [5.11.0] - 2026-08-11
 
 ### Fixed

--- a/docs/decisions/2026-06-10-release-process.md
+++ b/docs/decisions/2026-06-10-release-process.md
@@ -37,9 +37,20 @@ Stop cutting a release per work item. The flow is now:
 - Full suite green → `chore: release vX.Y.Z` on develop → `--no-ff` merge to
   `main` → tag → push → GitHub release → deploy (compose build + up) → bump the
   marketplace pin and refresh the installed plugin (both below).
-- Push the tag explicitly (`git push origin vX.Y.Z`). `--follow-tags` skips
-  lightweight tags, and `gh release create` refuses to run until the tag is on
-  the remote.
+- Push the tag explicitly (`git push origin vX.Y.Z`) — `--follow-tags` skips
+  lightweight tags — and create the release with `--verify-tag`:
+
+  ```bash
+  git push origin vX.Y.Z
+  gh release create vX.Y.Z --verify-tag --title ... --notes ...
+  ```
+
+  `--verify-tag` is what enforces the invariant. Without it, `gh release
+  create` creates any missing tag from the latest state of the default branch,
+  so a forgotten or failed push publishes a release pointing at the wrong
+  commit. During v5.11.0 `gh` did refuse — but only because the tag existed
+  locally and not on the remote, which it treats as ambiguous; that refusal is
+  a side effect of one particular state, not a guarantee to rely on.
 - A client-only release (hooks, skills, CLI — no `app.py` or backend change
   beyond its version string) needs no deploy. Skipping it leaves the running
   backend reporting the previous version, which is cosmetic; redeploying a
@@ -69,15 +80,40 @@ Stop cutting a release per work item. The flow is now:
   Confirm by checking that `installed_plugins.json`'s `gitCommitSha` equals the
   release commit — not just that `version` moved, which can advance while the
   files on disk do not.
-- **Old cache directories linger and can still execute.** `claude plugin update`
-  adds a new versioned directory rather than replacing the old one, and stale
-  ones stay marked `.in_use`. A v5.4.0 directory from four months earlier was
-  still running hooks during v5.11.0 and emitting a bogus "Backend Update
-  Available — latest is v5.7.0" banner, sourced from an `assets/BACKEND_VERSION`
-  that no current version even ships (see the dangling-path note in
-  `memory-recall.sh`). After restarting, prune the directories under
-  `~/.claude/plugins/cache/dk-marketplace/memories/` that are not the current
-  version.
+- **Old cache directories linger and can still execute — do not blind-prune
+  them.** `claude plugin update` adds a new versioned directory rather than
+  replacing the old one, and long-lived sessions keep running from whichever
+  path they started with. During v5.11.0 a v5.4.0 directory from four months
+  earlier was still executing hooks and emitting a bogus "Backend Update
+  Available — latest is v5.7.0" banner, sourced from an
+  `assets/BACKEND_VERSION` that no current version even ships (see the
+  dangling-path note in `memory-recall.sh`).
+
+  `.in_use` is **a directory of per-process lease records**, not a stale
+  boolean left behind by `update`: each entry is a PID whose contents look like
+  `{"pid":11409,"procStart":"..."}`. Testing `[ -e .in_use ]` therefore says
+  nothing about whether anything is actually using the directory — an empty
+  lease directory persists after every session that held it exits. Count live
+  leases instead, and note that restarting one session does not release
+  another's:
+
+  ```bash
+  for d in ~/.claude/plugins/cache/dk-marketplace/memories/*/; do
+    live=0
+    for pid in $(ls "$d.in_use" 2>/dev/null); do
+      kill -0 "$pid" 2>/dev/null && live=$((live+1))
+    done
+    echo "$(basename "$d"): $live live lease(s)"
+  done
+  ```
+
+  (`ls` rather than a glob: under zsh's default `nomatch`, an empty
+  `.in_use/*` aborts the loop instead of yielding zero iterations.)
+
+  Delete a non-current directory only once it reports zero live leases. At the
+  time of the v5.11.0 release the v5.4.0 directory held seven live leases, all
+  with `--plugin-dir` pointing into it, so removing it would have pulled hook
+  and skill files out from under seven running sessions.
 - Anything user-behavior-changing ships behind an eval gate where one exists
   (active-search eval for hook behavior, tier-1 recall A/B for retrieval).
 

--- a/docs/decisions/2026-06-10-release-process.md
+++ b/docs/decisions/2026-06-10-release-process.md
@@ -21,7 +21,9 @@ Stop cutting a release per work item. The flow is now:
 
 - Bump every version string (the eight, current as of v5.11.0: `pyproject.toml`,
   `mcp-server/package.json` + lockfile, `uv.lock`,
-  `mcp-server/assets/backend/BACKEND_VERSION`, `app.py` (FastAPI + /health),
+  `mcp-server/assets/backend/BACKEND_VERSION` (**skip on a client-only release
+  that is not deploying — see the client-only note below**),
+  `app.py` (FastAPI + /health),
   `tests/test_api_contract_compat.py`, `plugins/memories/.codex-plugin/plugin.json`,
   `mcp-server/assets/claude-code/.claude-plugin/plugin.json` (Claude Code plugin
   manifest — `dk-marketplace/sync.sh` reads its version into `marketplace.json`,
@@ -51,10 +53,29 @@ Stop cutting a release per work item. The flow is now:
   commit. During v5.11.0 `gh` did refuse — but only because the tag existed
   locally and not on the remote, which it treats as ambiguous; that refusal is
   a side effect of one particular state, not a guarantee to rely on.
-- A client-only release (hooks, skills, CLI — no `app.py` or backend change
-  beyond its version string) needs no deploy. Skipping it leaves the running
-  backend reporting the previous version, which is cosmetic; redeploying a
-  live backend is not, so do not do it for a change that cannot affect it.
+- **A client-only release (hooks, skills, CLI — no backend change) needs no
+  deploy, and must therefore NOT bump `mcp-server/assets/backend/BACKEND_VERSION`.**
+  That file describes the deployed backend; bumping it without deploying makes
+  it describe something that does not exist. The cost is not cosmetic:
+  `runDoctor` (`mcp-server/cli/index.mjs`) compares the marker against
+  `/health` and, on any difference, prints `(mismatch — consider \`memories
+  update\`)`. `memories update` routes to `runInitOrUpdate`, which rewires
+  clients and only offers to provision a backend when the health check *fails* —
+  so against a healthy older backend the recommendation cannot do anything. The
+  result is a permanent warning pointing at a command that will never clear it.
+  Leave the marker at the deployed version and let the next backend-affecting
+  release move both together.
+
+  Known exception in flight: v5.11.0 bumped the marker to 5.11.0 while
+  deliberately skipping the deploy (client-only fixes), so `doctor` reports a
+  mismatch against a 5.10.0 backend until the next deploy. Do not "fix" this by
+  redeploying a live backend for a change that cannot affect it.
+
+  The comparison itself is a bare `!==` in both `runDoctor` and
+  `memory-recall.sh`'s update banner, so it also fires when the deployed
+  backend is *newer* than the package — which is how a stale plugin cache
+  produced "Running v5.10.0, latest is v5.7.0". Worth making direction-aware;
+  tracked separately from this doc change.
 - **Bump the marketplace pin.** `dk-marketplace`'s `memories` entry pins its
   `git-subdir` source to an immutable `sha`, so the plugin does NOT track
   `main` — a release is invisible to plugin consumers until that SHA is

--- a/docs/decisions/2026-06-10-release-process.md
+++ b/docs/decisions/2026-06-10-release-process.md
@@ -21,9 +21,7 @@ Stop cutting a release per work item. The flow is now:
 
 - Bump every version string (the eight, current as of v5.11.0: `pyproject.toml`,
   `mcp-server/package.json` + lockfile, `uv.lock`,
-  `mcp-server/assets/backend/BACKEND_VERSION` (**skip on a client-only release
-  that is not deploying — see the client-only note below**),
-  `app.py` (FastAPI + /health),
+  `mcp-server/assets/backend/BACKEND_VERSION`, `app.py` (FastAPI + /health),
   `tests/test_api_contract_compat.py`, `plugins/memories/.codex-plugin/plugin.json`,
   `mcp-server/assets/claude-code/.claude-plugin/plugin.json` (Claude Code plugin
   manifest — `dk-marketplace/sync.sh` reads its version into `marketplace.json`,
@@ -35,6 +33,9 @@ Stop cutting a release per work item. The flow is now:
   Grep the old version project-wide before committing, and include `*.mjs`/`*.js`
   in that grep: a hardcoded `version:` in `mcp-server/lib-tools.mjs` was missed
   for two releases because earlier sweeps only checked json/toml/py/md.
+  The backend-facing subset (`BACKEND_VERSION`, both `app.py` strings, the
+  health-contract assertion) is exempt on a client-only release — see the
+  client-only note below; those four move together or not at all.
 - Retitle CHANGELOG `[Unreleased]` to the version + date.
 - Full suite green → `chore: release vX.Y.Z` on develop → `--no-ff` merge to
   `main` → tag → push → GitHub release → deploy (compose build + up) → bump the
@@ -54,17 +55,27 @@ Stop cutting a release per work item. The flow is now:
   locally and not on the remote, which it treats as ambiguous; that refusal is
   a side effect of one particular state, not a guarantee to rely on.
 - **A client-only release (hooks, skills, CLI — no backend change) needs no
-  deploy, and must therefore NOT bump `mcp-server/assets/backend/BACKEND_VERSION`.**
-  That file describes the deployed backend; bumping it without deploying makes
-  it describe something that does not exist. The cost is not cosmetic:
+  deploy, and must freeze every backend-facing version source together:**
+  `mcp-server/assets/backend/BACKEND_VERSION`, **both** version strings in
+  `app.py` (the FastAPI arg and the `/health` body), and the assertion in
+  `tests/test_api_contract_compat.py`. Freezing only the marker is worse than
+  freezing nothing: the marker would then claim the old version while a backend
+  built from that same tag reports the new one, so anyone running it gets the
+  mismatch immediately. A `pytest` guard
+  (`test_backend_version_marker_matches_health_version`) now enforces the pair,
+  so a half-applied bump fails CI rather than shipping. `pyproject.toml` and
+  `uv.lock` are Python package metadata that nothing compares against the
+  marker, so they track the release version as usual.
+
+  Why the marker matters at all — the cost is not cosmetic:
   `runDoctor` (`mcp-server/cli/index.mjs`) compares the marker against
   `/health` and, on any difference, prints `(mismatch — consider \`memories
   update\`)`. `memories update` routes to `runInitOrUpdate`, which rewires
   clients and only offers to provision a backend when the health check *fails* —
   so against a healthy older backend the recommendation cannot do anything. The
   result is a permanent warning pointing at a command that will never clear it.
-  Leave the marker at the deployed version and let the next backend-affecting
-  release move both together.
+  Leave all four backend-facing sources at the deployed version and let the next
+  backend-affecting release move them together.
 
   Known exception in flight: v5.11.0 bumped the marker to 5.11.0 while
   deliberately skipping the deploy (client-only fixes), so `doctor` reports a

--- a/docs/decisions/2026-06-10-release-process.md
+++ b/docs/decisions/2026-06-10-release-process.md
@@ -19,7 +19,7 @@ Stop cutting a release per work item. The flow is now:
 
 ## Mechanics of a promotion
 
-- Bump every version string (the eight, current as of v5.10.0: `pyproject.toml`,
+- Bump every version string (the eight, current as of v5.11.0: `pyproject.toml`,
   `mcp-server/package.json` + lockfile, `uv.lock`,
   `mcp-server/assets/backend/BACKEND_VERSION`, `app.py` (FastAPI + /health),
   `tests/test_api_contract_compat.py`, `plugins/memories/.codex-plugin/plugin.json`,
@@ -35,8 +35,15 @@ Stop cutting a release per work item. The flow is now:
   for two releases because earlier sweeps only checked json/toml/py/md.
 - Retitle CHANGELOG `[Unreleased]` to the version + date.
 - Full suite green → `chore: release vX.Y.Z` on develop → `--no-ff` merge to
-  `main` → tag → push → GitHub release → deploy (compose build + up) → sync
-  the installed plugin cache if hook/skill files changed.
+  `main` → tag → push → GitHub release → deploy (compose build + up) → bump the
+  marketplace pin and refresh the installed plugin (both below).
+- Push the tag explicitly (`git push origin vX.Y.Z`). `--follow-tags` skips
+  lightweight tags, and `gh release create` refuses to run until the tag is on
+  the remote.
+- A client-only release (hooks, skills, CLI — no `app.py` or backend change
+  beyond its version string) needs no deploy. Skipping it leaves the running
+  backend reporting the previous version, which is cosmetic; redeploying a
+  live backend is not, so do not do it for a change that cannot affect it.
 - **Bump the marketplace pin.** `dk-marketplace`'s `memories` entry pins its
   `git-subdir` source to an immutable `sha`, so the plugin does NOT track
   `main` — a release is invisible to plugin consumers until that SHA is
@@ -44,6 +51,33 @@ Stop cutting a release per work item. The flow is now:
   session transcripts and carry the backend credential, so a fresh clone must
   never execute upstream code that changed after review. Get the commit with
   `git rev-list -n1 vX.Y.Z`.
+- **Then refresh the installed plugin — the pin bump alone does nothing to it.**
+  An already-installed plugin keeps running from its own cache directory until
+  explicitly updated, so bumping the pin makes the release available without
+  delivering it. Verified the hard way during v5.11.0: the marketplace
+  advertised 5.10.0 while `~/.claude/plugins/installed_plugins.json` still
+  recorded `memories@dk-marketplace` at 5.9.0 (`gitCommitSha` = v5.9.0's merge
+  commit), and the hooks actually firing were a release behind — with the very
+  bug the newer version fixed. Both commands are non-interactive:
+
+  ```bash
+  claude plugin marketplace update dk-marketplace
+  claude plugin update memories@dk-marketplace
+  ```
+
+  Then **restart Claude Code** (the update prints "Restart to apply changes").
+  Confirm by checking that `installed_plugins.json`'s `gitCommitSha` equals the
+  release commit — not just that `version` moved, which can advance while the
+  files on disk do not.
+- **Old cache directories linger and can still execute.** `claude plugin update`
+  adds a new versioned directory rather than replacing the old one, and stale
+  ones stay marked `.in_use`. A v5.4.0 directory from four months earlier was
+  still running hooks during v5.11.0 and emitting a bogus "Backend Update
+  Available — latest is v5.7.0" banner, sourced from an `assets/BACKEND_VERSION`
+  that no current version even ships (see the dangling-path note in
+  `memory-recall.sh`). After restarting, prune the directories under
+  `~/.claude/plugins/cache/dk-marketplace/memories/` that are not the current
+  version.
 - Anything user-behavior-changing ships behind an eval gate where one exists
   (active-search eval for hook behavior, tier-1 recall A/B for retrieval).
 

--- a/tests/test_api_contract_compat.py
+++ b/tests/test_api_contract_compat.py
@@ -80,3 +80,29 @@ def test_add_memory_contract_shape(client):
     assert response.status_code == 200
     body = response.json()
     assert {"success", "id", "message"} <= set(body)
+
+
+def test_backend_version_marker_matches_health_version(client):
+    """The packaged BACKEND_VERSION marker and the version /health reports must
+    move together.
+
+    `runDoctor` compares these two exact values and, on any difference, prints
+    a mismatch recommending `memories update` — a command that only rewires
+    clients and cannot update a running backend. So a checkout where they
+    disagree produces a permanent, unactionable warning for anyone who builds
+    the backend from it. A client-only release must freeze both rather than
+    bumping one.
+    """
+    from pathlib import Path
+
+    marker = (
+        Path(__file__).parent.parent / "mcp-server" / "assets" / "backend" / "BACKEND_VERSION"
+    ).read_text(encoding="utf-8").strip()
+
+    test_client, _ = client
+    reported = test_client.get("/health").json()["version"]
+
+    assert marker == reported, (
+        f"BACKEND_VERSION says {marker!r} but /health reports {reported!r}. "
+        "These are compared by `memories doctor`; bump both or neither."
+    )

--- a/tests/test_api_contract_compat.py
+++ b/tests/test_api_contract_compat.py
@@ -82,16 +82,19 @@ def test_add_memory_contract_shape(client):
     assert {"success", "id", "message"} <= set(body)
 
 
-def test_backend_version_marker_matches_health_version(client):
-    """The packaged BACKEND_VERSION marker and the version /health reports must
-    move together.
+def test_backend_version_sources_agree(client):
+    """Every backend-facing version source must move together: the packaged
+    BACKEND_VERSION marker, the version /health reports, and the FastAPI
+    metadata version (served as OpenAPI `info.version`).
 
-    `runDoctor` compares these two exact values and, on any difference, prints
-    a mismatch recommending `memories update` — a command that only rewires
-    clients and cannot update a running backend. So a checkout where they
-    disagree produces a permanent, unactionable warning for anyone who builds
-    the backend from it. A client-only release must freeze both rather than
-    bumping one.
+    `runDoctor` compares the marker against /health and, on any difference,
+    prints a mismatch recommending `memories update` — a command that only
+    rewires clients and cannot update a running backend, so a checkout where
+    they disagree produces a permanent, unactionable warning. The FastAPI
+    metadata is public API surface, and nothing else asserts it, so a bump
+    applied there alone would otherwise ship silently.
+
+    A client-only release must freeze all of these rather than bumping some.
     """
     from pathlib import Path
 
@@ -101,8 +104,15 @@ def test_backend_version_marker_matches_health_version(client):
 
     test_client, _ = client
     reported = test_client.get("/health").json()["version"]
+    metadata = test_client.app.version
+    openapi = test_client.get("/openapi.json").json()["info"]["version"]
 
-    assert marker == reported, (
-        f"BACKEND_VERSION says {marker!r} but /health reports {reported!r}. "
-        "These are compared by `memories doctor`; bump both or neither."
+    assert marker == reported == metadata == openapi, (
+        "backend version sources disagree — bump all or none:\n"
+        f"  BACKEND_VERSION      {marker!r}\n"
+        f"  /health              {reported!r}\n"
+        f"  FastAPI(version=)    {metadata!r}\n"
+        f"  openapi info.version {openapi!r}\n"
+        "The first two are compared by `memories doctor`; the rest are public "
+        "API metadata."
     )


### PR DESCRIPTION
## Why

Bumping the `dk-marketplace` pin makes a release *available*; it does not *deliver* it. An installed plugin keeps running from its own cache directory until explicitly updated, and nothing in the release process said so.

Consequence, observed during v5.11.0: the marketplace advertised 5.10.0 while `installed_plugins.json` still recorded `memories@dk-marketplace` at 5.9.0 (`gitCommitSha` = v5.9.0's merge commit). The hooks actually firing were a release behind — including the hardcoded `mcp__memories__` matcher that v5.11.0 fixes. The machine looked current and was not.

## What this adds

- The two non-interactive refresh commands, plus the required restart.
- A verification that checks `gitCommitSha` against the release commit, not the `version` field — `version` can advance while the files on disk do not.
- Old cache directories are **not** replaced and stay marked `.in_use`. A v5.4.0 directory from four months earlier was still executing hooks and emitting a bogus "Backend Update Available — latest is v5.7.0" banner, sourced from an `assets/BACKEND_VERSION` that no current version ships. Prune after restarting.
- Lightweight tags need an explicit `git push origin vX.Y.Z`; `--follow-tags` skips them and `gh release create` refuses until the tag is on the remote. Hit this during v5.11.0.
- A client-only release (hooks/skills/CLI, no backend change beyond its version string) needs no deploy — and shouldn't trigger one, since redeploying a live backend carries real risk for a change that cannot affect it.
- Version-string marker refreshed to v5.11.0.

Docs only; no code paths touched. Suite run anyway: 1764 pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)