### PR TITLE
docs(readme): replace the cloud plugin-enablement step with the setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,7 +1200,7 @@ npx memories-mcp@latest init
 
 Auto-detects Claude Code, Codex, and Cursor (or restrict with `--claude` / `--codex` / `--cursor` / `--generic`); prompts for backend URL/API key (or `--url` / `--api-key`); checks backend health and, interactively, offers to bootstrap it with Docker (`~/.config/memories/docker-compose.yml`) if it's not reachable; wires hooks/skills/MCP config per target. `--yes` skips all prompts (including the bootstrap offer — an unreachable backend is logged and skipped, not auto-provisioned); `--dry-run` previews without writing. Companion commands: `memories doctor` (status + backend health + version check), `memories update` (re-wire after upgrading), `memories uninstall`. Windows has no bash, so `init` restricts to the generic target there. Other MCP clients: use the generic snippet from `memories init --generic`, or see [`GETTING_STARTED.md`](GETTING_STARTED.md#4-install-integrations-recommended).
 
-`memories-mcp` has not published its first npm release yet — `npx memories-mcp@latest` will resolve once it does. It does not (yet) cover OpenCode or OpenClaw; use `install.sh` below for those.
+`memories-mcp` is published on npm (first release 2026-08-10), so `npx memories-mcp@latest` resolves — this is the command the cloud setup script uses. It does not cover OpenCode or OpenClaw; use `install.sh` below for those.
 
 **Legacy: `install.sh` (deprecated, still works this release — removed next release)**
 

--- a/README.md
+++ b/README.md
@@ -750,25 +750,37 @@ See `mcp-server/remote/server.mjs` for the full env contract (`REMOTE_MCP_AUTH=n
 
 A cloud session runs in a fresh VM built from a git clone of your repository. Nothing from your local `~/.claude` is present — not your user-level `CLAUDE.md`, skills, hooks, `enabledPlugins`, or `~/.claude.json` MCP servers. That splits Memories into two halves:
 
-| | Cloud session | What it takes |
-|---|---|---|
-| **Tools** (`memory_search`, `memory_add`, …) | Works with no setup | The claude.ai connector above travels with your account, and its traffic is proxied by Anthropic rather than the session's network |
-| **Hooks** (automatic recall + extraction) | Only if the repo opts in | The three steps below — miss any one and it fails silently |
+Memories reaches an agent through three independent layers, and they do different jobs:
+
+| Layer | What it provides | Cloud session | What it takes |
+|---|---|---|---|
+| **Tools** (`memory_search`, `memory_add`, …) | The *capability* — the agent can reach memories when it decides to | Works with no setup | The claude.ai connector above travels with your account, and its traffic is proxied by Anthropic rather than the session's network |
+| **Hooks** (SessionStart recall, Stop extraction, …) | The *reflex* — recall and capture happen at lifecycle boundaries whether or not the agent thinks to ask | Only if the environment installs them | The three steps below — miss any one and it fails silently |
+| **`CLAUDE.md` rules** | The *policy* — when to search, how to phrase recalled context, when to store | Only if the environment installs them | Written by the same `init` command as the hooks |
+
+The layers are complementary, not redundant. Tools without hooks means memories are reachable but nothing recalls them automatically. Hooks without the rules means context gets injected but the agent may ignore it, paraphrase it as its own, or re-ask something already answered — the rules are what turn injected text into behaviour ("search before asking a clarifying question", "never say *memory confirms*", "preserve `until`/`unless` clauses verbatim"). Tools plus rules without hooks means the agent searches only when it remembers to.
+
+A cloud session gets the first for free and the other two only from the setup script below.
 
 If you only need Claude to be *able* to reach your memories, the connector alone is enough; stop here. The rest buys you automatic per-prompt recall and end-of-session extraction.
 
-**1. Commit the plugin enablement.** Project settings are the only channel that reaches a cloud session, so `.claude/settings.json` must be committed (this repo ships one):
+**1. Install the hooks from the environment's setup script.**
 
-```json
-{
-  "extraKnownMarketplaces": {
-    "dk-marketplace": { "source": { "source": "github", "repo": "divyekant/dk-marketplace" } }
-  },
-  "enabledPlugins": { "memories@dk-marketplace": true }
-}
+```bash
+npx -y memories-mcp init --claude --yes \
+  --url https://memory.yourdomain.com \
+  --mcp-name YourMcpServerName \
+  --no-persist-api-key
 ```
 
-If your `.gitignore` excludes `.claude/`, add a negation for this one file — see this repo's `.gitignore` for the pattern.
+Put that in the cloud environment's **Setup script** box (it runs before Claude Code launches). It writes the hooks to `~/.claude/hooks/memory/`, wires them into `~/.claude/settings.json`, and appends the behavioural rules to `~/.claude/CLAUDE.md`.
+
+> **Committing `enabledPlugins` does NOT work in cloud — do not try it.** A repo-committed `.claude/settings.json` declaring `extraKnownMarketplaces` and `enabledPlugins` looks like it should be enough, but the container performs no marketplace fetch and no plugin install, so none of the hook events register. Verified in a real container: `installed_plugins.json` was `{"plugins":{}}`, `~/.claude/plugins/marketplaces/` did not exist, and `hook.log` was never created. It is not a network problem — the marketplace clones fine from inside the VM. The setup script sidesteps the broken step rather than working around it.
+
+Two flags earn their place:
+
+- `--url` — the setup script runs *before* the environment variables exist, so the installer cannot read `MEMORIES_URL` and would otherwise persist its `http://localhost:8900` default into `~/.config/memories/env`. Hooks let a real environment variable win over that file, so it still works without the flag, but `memories doctor` and anything else reading the file would report the wrong backend. Pass the URL and the file stays honest. It is not a secret.
+- `--no-persist-api-key` — keeps `MEMORIES_API_KEY` out of the MCP entry in `settings.json`. The key comes from the environment instead, so it never lands in a config file. Do **not** pass `--api-key`: that would write the credential into both the setup script and `~/.config/memories/env`.
 
 **2. Set the environment variables.** On claude.ai/code, click the cloud icon showing the environment's name in the row above the message box, then **Add cloud environment** (or the gear icon on an existing one). The dialog holds environment variables in `.env` format:
 


### PR DESCRIPTION
## Why

README step 1 for cloud sessions documented **the approach that does not work**. It told readers to commit `.claude/settings.json` with `extraKnownMarketplaces` + `enabledPlugins` — but a cloud container performs no marketplace fetch and no plugin install, so none of the 11 hook events register.

Verified in a real container:

```
~/.claude/plugins/installed_plugins.json  ->  {"version": 2, "plugins": {}}
~/.claude/plugins/marketplaces/           ->  does not exist
~/.config/memories/hook.log               ->  never created
```

Anyone following the README got tools-only, with no explanation of why automatic recall never happened. fplguru#780 was an attempt at exactly this and was closed as inert.

## What changed

**Step 1 is now the environment's setup script**, with an explicit "do not try this" note carrying the evidence, so the plugin route isn't re-derived by the next person.

Both flags are justified inline rather than presented as magic:

- `--url` — the setup script runs *before* the environment variables exist, so without it the installer persists its `localhost:8900` default into `~/.config/memories/env`. Harmless since the environment now wins, but it makes `memories doctor` report the wrong backend.
- `--no-persist-api-key` — keeps the credential out of `settings.json`. Explicitly warns against `--api-key`, which would write the secret into both the setup script and the env file.

Steps 2 (environment variables) and 3 (network allowlist) were correct and are unchanged.

**Also documents the three layers**, which the section framed as two and never explained:

| Layer | What it provides |
|---|---|
| Tools | the *capability* — reachable when the agent decides to look |
| Hooks | the *reflex* — recall and capture at lifecycle boundaries regardless |
| `CLAUDE.md` rules | the *policy* — when to search, how to phrase recalled context |

The rules layer is what turns injected context into behaviour rather than text the agent may ignore, paraphrase as its own, or contradict. `init` installs it; that was never written down.

Docs only — no code paths touched.

> **Note for review:** `pytest` currently fails at collection on `develop` for unrelated reasons — seven test files carry uncommitted local changes importing `project_memory`, a module not in the repo (concurrent work in progress, untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)