### PR TITLE
fix: protect project namespaces from pruning

### DIFF
--- a/consolidator.py
+++ b/consolidator.py
@@ -11,7 +11,11 @@ from collections import Counter
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-from project_memory import TrustedAuthorship, is_reserved_namespace_source
+from project_memory import (
+    TrustedAuthorship,
+    is_project_namespace_prefix,
+    is_reserved_namespace_source,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -332,6 +336,8 @@ def find_prune_candidates(
 
     for mem in all_memories:
         if not mem:
+            continue
+        if is_project_namespace_prefix(mem.get("source")):
             continue
         # Pinned memories are operator-protected; archived memories are
         # supersede-chain version history. Neither is ever prunable.

--- a/project_memory.py
+++ b/project_memory.py
@@ -105,6 +105,12 @@ def is_project_source(source: Any) -> bool:
     return parsed is not None and parsed.is_project
 
 
+def is_project_namespace_prefix(source: Any) -> bool:
+    """Return whether *source* begins with the reserved project namespace."""
+
+    return isinstance(source, str) and source.startswith("project/")
+
+
 def is_person_source(source: Any) -> bool:
     """Return ``True`` only for a strict ``person/<principal>/<id>/<kind>``."""
 

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -372,12 +372,44 @@ class TestConsolidation:
 class TestPruning:
     """Tests for find_prune_candidates()."""
 
+    def test_pruning_skips_every_project_prefix_but_not_person_memory(self):
+        from consolidator import find_prune_candidates
+
+        stale_date = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
+        candidates = find_prune_candidates(
+            all_memories=[
+                _make_memory(
+                    1,
+                    "Shared project knowledge",
+                    source="project/fplguru/knowledge",
+                    created_at=stale_date,
+                ),
+                _make_memory(
+                    2,
+                    "Legacy project note",
+                    source="project/notes",
+                    created_at=stale_date,
+                ),
+                _make_memory(
+                    3,
+                    "Private memory",
+                    source="person/alice/fplguru/knowledge",
+                    created_at=stale_date,
+                ),
+            ],
+            unretrieved_ids=[1, 2, 3],
+        )
+
+        assert [item["id"] for item in candidates] == [3]
+
     def test_identifies_old_unretrieved_detail(self):
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=112)).isoformat()
-        m0 = _make_memory(0, "Old detail", category="detail", created_at=old_date)
-        m1 = _make_memory(1, "Recent detail", category="detail")
+        m0 = _make_memory(
+            0, "Old detail", source="legacy/decisions", category="detail", created_at=old_date
+        )
+        m1 = _make_memory(1, "Recent detail", source="legacy/decisions", category="detail")
 
         candidates = find_prune_candidates(
             all_memories=[m0, m1],
@@ -394,7 +426,9 @@ class TestPruning:
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=112)).isoformat()
-        m0 = _make_memory(0, "Old decision", category="decision", created_at=old_date)
+        m0 = _make_memory(
+            0, "Old decision", source="legacy/decisions", category="decision", created_at=old_date
+        )
 
         candidates = find_prune_candidates(
             all_memories=[m0],
@@ -410,7 +444,13 @@ class TestPruning:
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=150)).isoformat()
-        m0 = _make_memory(0, "Very old decision", category="decision", created_at=old_date)
+        m0 = _make_memory(
+            0,
+            "Very old decision",
+            source="legacy/decisions",
+            category="decision",
+            created_at=old_date,
+        )
 
         candidates = find_prune_candidates(
             all_memories=[m0],
@@ -426,7 +466,9 @@ class TestPruning:
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=200)).isoformat()
-        m0 = _make_memory(0, "Old but retrieved", category="detail", created_at=old_date)
+        m0 = _make_memory(
+            0, "Old but retrieved", source="legacy/decisions", category="detail", created_at=old_date
+        )
 
         candidates = find_prune_candidates(
             all_memories=[m0],
@@ -441,7 +483,9 @@ class TestPruning:
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=112)).isoformat()
-        m0 = _make_memory(0, "Old learning", category="learning", created_at=old_date)
+        m0 = _make_memory(
+            0, "Old learning", source="legacy/decisions", category="learning", created_at=old_date
+        )
 
         candidates = find_prune_candidates(
             all_memories=[m0],
@@ -461,7 +505,13 @@ class TestPruning:
         old_date = (datetime.now(timezone.utc) - timedelta(days=100)).strftime(
             "%Y-%m-%dT%H:%M:%S.%fZ"
         )
-        m0 = _make_memory(0, "Old detail with Z", category="detail", created_at=old_date)
+        m0 = _make_memory(
+            0,
+            "Old detail with Z",
+            source="legacy/decisions",
+            category="detail",
+            created_at=old_date,
+        )
 
         candidates = find_prune_candidates(
             all_memories=[m0],
@@ -475,7 +525,7 @@ class TestPruning:
         from consolidator import find_prune_candidates
 
         old_date = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
-        m0 = _make_memory(0, "No category", created_at=old_date)
+        m0 = _make_memory(0, "No category", source="legacy/decisions", created_at=old_date)
         del m0["category"]
 
         candidates = find_prune_candidates(

--- a/tests/test_project_memory.py
+++ b/tests/test_project_memory.py
@@ -10,6 +10,7 @@ from project_memory import (
     PROJECT_KINDS,
     ProjectMemoryPolicyError,
     TrustedAuthorship,
+    is_project_namespace_prefix,
     is_project_source,
     normalize_origin_client,
     parse_memory_source,
@@ -58,6 +59,18 @@ def test_parse_memory_source_accepts_strict_project_namespaces(
 def test_parse_memory_source_leaves_invalid_similar_sources_legacy(source):
     assert parse_memory_source(source) is None
     assert not is_project_source(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "project/fplguru/knowledge",
+        "project/notes",
+        "project/decisions.md",
+    ],
+)
+def test_project_namespace_prefix_includes_strict_and_legacy(source):
+    assert is_project_namespace_prefix(source) is True
 
 
 def test_project_kinds_are_exactly_the_declared_four():


### PR DESCRIPTION
## Summary

- add a narrow `is_project_namespace_prefix()` policy helper
- exclude every `project/`-prefixed source from the shared pruning selector
- protect strict project sources and malformed legacy paths such as `project/notes`
- preserve existing pruning behavior for `person/*` and other private/legacy sources

## Root cause

The scheduled and manual pruning paths both call `find_prune_candidates()`, which previously considered stale, unretrieved project memories eligible for hard deletion. Phase 1 introduced durable shared project namespaces, so retrieval age is not a safe deletion signal for those records.

## Safety and impact

This is the independently deployable prerequisite for Phase 2. It changes only pruning candidate selection. It does not enable promotion, activate FPLGuru, create keys, add repository configuration, seed shared history, or modify production data.

## Verification

- red-first focused regression: `4 failed` before production changes
- focused regression after implementation: `4 passed`
- prescribed suite: `119 passed, 1 known local-Qdrant warning`
- controller rerun: `119 passed, 1 known local-Qdrant warning`
- `git diff --check`: clean
- independent task review: spec PASS, quality APPROVED, no findings

Exact commit: `8ab6692102eba1977cf9e9b3f86821524851384a`